### PR TITLE
[INJIMOB-2311]: Update Issuance date validation with tolerance of 3sec.

### DIFF
--- a/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/utils/DateUtils.kt
+++ b/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/utils/DateUtils.kt
@@ -79,7 +79,10 @@ object DateUtils {
         }
 
 
-        if (!isDatePassedCurrentDate(vcJsonObject.optString(ISSUANCE_DATE))) {
+        val issuanceDate: Date = parseDate(vcJsonObject.optString(ISSUANCE_DATE))
+            ?: throw ValidationException(ERROR_ISSUANCE_DATE_INVALID, "${ERROR_CODE_INVALID}${ISSUANCE_DATE}")
+
+        if (issuanceDate.isFutureDateWithTolerance()) {
             throw ValidationException(ERROR_CURRENT_DATE_BEFORE_ISSUANCE_DATE,
                 ERROR_CODE_CURRENT_DATE_BEFORE_ISSUANCE_DATE
             )
@@ -112,4 +115,12 @@ object DateUtils {
         return inputDate.isNotEmpty() && isDatePassedCurrentDate(inputDate)
     }
 
+}
+
+fun Date.isFutureDateWithTolerance(toleranceInMilliSeconds: Long = 3000): Boolean {
+    val currentTime = System.currentTimeMillis()
+    val inputDateTime = this.time
+
+    val upperBound = currentTime + toleranceInMilliSeconds
+    return inputDateTime > upperBound
 }

--- a/vc-verifier/kotlin/vcverifier/src/test/java/io/mosip/vercred/vcverifier/utils/UtilsTest.kt
+++ b/vc-verifier/kotlin/vcverifier/src/test/java/io/mosip/vercred/vcverifier/utils/UtilsTest.kt
@@ -8,10 +8,10 @@ import org.junit.jupiter.api.Assertions.assertArrayEquals
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.io.ByteArrayOutputStream
 import java.util.Calendar
+import java.util.Date
 
 
 class UtilsTest {
@@ -132,5 +132,47 @@ class UtilsTest {
                 36
             ), (digest)
         )
+    }
+
+    @Test
+    fun `test when issuanceDate time is not future date and 10 seconds less than currentDate time `() {
+        val currentDate = Date()
+        val issuanceDate = Date(currentDate.time-10000)
+        val result = issuanceDate.isFutureDateWithTolerance()
+        assertFalse(result)
+    }
+
+    @Test
+    fun `test when issuanceDate time is not future date and 3 seconds less than currentDate time `() {
+        val currentDate = Date()
+        val issuanceDate = Date(currentDate.time-3000)
+        val result = issuanceDate.isFutureDateWithTolerance()
+        assertFalse(result)
+    }
+
+    @Test
+    fun `test when issuanceDate time equal to future date time`() {
+        val issuanceDate = Date()
+        val result = issuanceDate.isFutureDateWithTolerance()
+        assertFalse(result)
+    }
+
+
+    @Test
+    fun `test when issuanceDate time is future date time but within tolerance range`() {
+        val currentDate = Date()
+        val issuanceDate = Date(currentDate.time+3000)
+
+        val result = issuanceDate.isFutureDateWithTolerance()
+        assertFalse(result)
+    }
+
+    @Test
+    fun `test when issuanceDate time is future date time but outside tolerance range`() {
+        val currentDate = Date()
+        val issuanceDate = Date(currentDate.time+5000)
+
+        val result = issuanceDate.isFutureDateWithTolerance()
+        assertTrue(result)
     }
 }


### PR DESCRIPTION
Update Issuance date validation with tolerance of 3sec.

For Example :
- If currentDateTime is **2023-12-02T17:36:13.644Z** and issuanceDateTime is **2023-12-02T17:36:15.644Z**, we will consider issuanceDateTime is not future date as we set tolerance of **3 seconds**.

-  If issuance date is **2023-12-02T17:36:20.644Z**, it will be considered as future date and validation error will be thrown