### PR TITLE
[INJIMOB-2712] Add sonar support for push trigger

### DIFF
--- a/.github/workflows/push-trigger.yml
+++ b/.github/workflows/push-trigger.yml
@@ -19,8 +19,6 @@ on:
       - 'injimob*'
       - 'develop'
       - 'master'
-      # To be removed
-      - sonar-testing
 
 jobs:
   build-maven-vc-verifier:

--- a/.github/workflows/push-trigger.yml
+++ b/.github/workflows/push-trigger.yml
@@ -33,7 +33,7 @@ jobs:
   sonar_analysis:
     needs: build-maven-vc-verifier
     if: "${{  github.event_name != 'pull_request' }}"
-    uses: tw-mosip/kattu/.github/workflows/gradle-sonar-analysis.yml@injimob-2712-add-gradle-workflow
+    uses: mosip/kattu/.github/workflows/gradlew-sonar-analysis.yml@master-java21
     with:
       SERVICE_LOCATION: vc-verifier/kotlin/vcverifier
     secrets:

--- a/.github/workflows/push-trigger.yml
+++ b/.github/workflows/push-trigger.yml
@@ -33,7 +33,7 @@ jobs:
 
   sonar_analysis:
     needs: build-maven-vc-verifier
-    if: "${{  github.event_name != 'pull_request' }}"
+    # if: "${{  github.event_name != 'pull_request' }}"
     uses: tw-mosip/kattu/.github/workflows/gradle-sonar-analysis.yml@injimob-2712-add-gradle-workflow
     with:
       SERVICE_LOCATION: vc-verifier/kotlin/vcverifier

--- a/.github/workflows/push-trigger.yml
+++ b/.github/workflows/push-trigger.yml
@@ -33,12 +33,10 @@ jobs:
   sonar_analysis:
     needs: build-maven-vc-verifier
     if: "${{  github.event_name != 'pull_request' }}"
-    uses: mosip/kattu/.github/workflows/gradlew-sonar-analysis.yml@master-java21
+    uses: tw-mosip/kattu/.github/workflows/gradle-sonar-analysis.yml@injimob-2712-add-gradle-workflow
     with:
       SERVICE_LOCATION: vc-verifier/kotlin/vcverifier
-      ANDROID_LOCATION: ''
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       SONAR_ORGANIZATION: ${{ secrets.ORG_KEY }}
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_INJI_TEAM }}
-

--- a/.github/workflows/push-trigger.yml
+++ b/.github/workflows/push-trigger.yml
@@ -19,6 +19,7 @@ on:
       - 'injimob*'
       - 'develop'
       - 'master'
+      - sonar-testing
 
 jobs:
   build-maven-vc-verifier:

--- a/.github/workflows/push-trigger.yml
+++ b/.github/workflows/push-trigger.yml
@@ -19,6 +19,7 @@ on:
       - 'injimob*'
       - 'develop'
       - 'master'
+      # To be removed
       - sonar-testing
 
 jobs:
@@ -33,7 +34,7 @@ jobs:
 
   sonar_analysis:
     needs: build-maven-vc-verifier
-    # if: "${{  github.event_name != 'pull_request' }}"
+    if: "${{  github.event_name != 'pull_request' }}"
     uses: tw-mosip/kattu/.github/workflows/gradle-sonar-analysis.yml@injimob-2712-add-gradle-workflow
     with:
       SERVICE_LOCATION: vc-verifier/kotlin/vcverifier

--- a/vc-verifier/kotlin/vcverifier/build.gradle.kts
+++ b/vc-verifier/kotlin/vcverifier/build.gradle.kts
@@ -5,7 +5,13 @@ plugins {
     alias(libs.plugins.dokka)
     signing
     id("org.sonarqube") version "5.1.0.4872"
+    jacoco
 }
+
+jacoco {
+    toolVersion = "0.8.8" // Ensure compatibility
+}
+
 
 android {
     namespace = "io.mosip.vccred.vcverifier"
@@ -50,14 +56,39 @@ dependencies {
     implementation("co.nstant.in:cbor:0.9")
     implementation ( "com.android.identity:identity-credential:20231002")
 
-
-
     testImplementation(libs.mockk)
     testImplementation(libs.junitJupiter)
 }
 
 tasks.withType<Test> {
     useJUnitPlatform()
+//    jacoco {
+//        isEnabled = true
+//    }
+//    finalizedBy(tasks.named("jacocoTestReport")) // Generate the Jacoco report after tests
+}
+
+tasks.register("jacocoTestReport", JacocoReport::class) {
+    dependsOn("test") // Make sure you adjust the task name based on your build variant (e.g., testDebugUnitTest)
+
+    reports {
+        xml.required = true
+        html.required = true
+        csv.required = false
+    }
+
+    val kotlinTree = fileTree(
+        mapOf(
+            "dir" to "${layout.buildDirectory.get()}/tmp/kotlin-classes/debug",
+            "includes" to listOf("**/*.class")
+        )
+    )
+    val coverageSourceDirs = arrayOf("src/main/java")
+
+    classDirectories.setFrom(files(kotlinTree))
+    sourceDirectories.setFrom(coverageSourceDirs)
+
+    executionData.setFrom(files("${layout.buildDirectory.get()}/jacoco/testDebugUnitTest.exec"))
 }
 
 tasks.register<Jar>("jarRelease") {

--- a/vc-verifier/kotlin/vcverifier/build.gradle.kts
+++ b/vc-verifier/kotlin/vcverifier/build.gradle.kts
@@ -62,10 +62,10 @@ dependencies {
 
 tasks.withType<Test> {
     useJUnitPlatform()
-//    jacoco {
-//        isEnabled = true
-//    }
-//    finalizedBy(tasks.named("jacocoTestReport")) // Generate the Jacoco report after tests
+    jacoco {
+        isEnabled = true
+    }
+    finalizedBy(tasks.named("jacocoTestReport"))
 }
 
 tasks.register("jacocoTestReport", JacocoReport::class) {

--- a/vc-verifier/kotlin/vcverifier/build.gradle.kts
+++ b/vc-verifier/kotlin/vcverifier/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
     `maven-publish`
     alias(libs.plugins.dokka)
     signing
-    id("org.sonarqube") version "6.0.1.5171"
+    id("org.sonarqube") version "5.1.0.4872"
 }
 
 android {
@@ -92,4 +92,15 @@ tasks.register<Jar>("sourcesJar") {
 apply(from = "publish-artifact.gradle")
 tasks.register("generatePom") {
     dependsOn("generatePomFileForAarPublication", "generatePomFileForJarReleasePublication")
+}
+
+sonarqube {
+    properties {
+        property( "sonar.java.binaries", "build/intermediates/javac/debug")
+        property( "sonar.language", "kotlin")
+        property( "soanr.exclusions", "**/build/**, **/*.kt.generated, **/R.java, **/BuildConfig.java")
+        property( "sonar.scm.disabled", "true")
+//        Test coverage can be supported with jacoco
+//        property( "sonar.coverage.jacoco.xmlReportPaths", "build/reports/jacoco/jacocoTestReport/jacocoTestReport.xml")
+    }
 }

--- a/vc-verifier/kotlin/vcverifier/build.gradle.kts
+++ b/vc-verifier/kotlin/vcverifier/build.gradle.kts
@@ -69,6 +69,8 @@ tasks.withType<Test> {
 }
 
 tasks.register("jacocoTestReport", JacocoReport::class) {
+    description = "Generates Test coverage report"
+    group = "TestReport"
     dependsOn("testDebugUnitTest")
 
     reports {

--- a/vc-verifier/kotlin/vcverifier/build.gradle.kts
+++ b/vc-verifier/kotlin/vcverifier/build.gradle.kts
@@ -131,7 +131,7 @@ sonarqube {
     properties {
         property( "sonar.java.binaries", "build/intermediates/javac/debug")
         property( "sonar.language", "kotlin")
-        property( "soanr.exclusions", "**/build/**, **/*.kt.generated, **/R.java, **/BuildConfig.java")
+        property( "sonar.exclusions", "**/build/**, **/*.kt.generated, **/R.java, **/BuildConfig.java")
         property( "sonar.scm.disabled", "true")
         property( "sonar.coverage.jacoco.xmlReportPaths", "build/reports/jacoco/jacocoTestReport/jacocoTestReport.xml")
     }

--- a/vc-verifier/kotlin/vcverifier/build.gradle.kts
+++ b/vc-verifier/kotlin/vcverifier/build.gradle.kts
@@ -69,7 +69,7 @@ tasks.withType<Test> {
 }
 
 tasks.register("jacocoTestReport", JacocoReport::class) {
-    dependsOn("test") // Make sure you adjust the task name based on your build variant (e.g., testDebugUnitTest)
+    dependsOn("testDebugUnitTest")
 
     reports {
         xml.required = true
@@ -131,7 +131,6 @@ sonarqube {
         property( "sonar.language", "kotlin")
         property( "soanr.exclusions", "**/build/**, **/*.kt.generated, **/R.java, **/BuildConfig.java")
         property( "sonar.scm.disabled", "true")
-//        Test coverage can be supported with jacoco
-//        property( "sonar.coverage.jacoco.xmlReportPaths", "build/reports/jacoco/jacocoTestReport/jacocoTestReport.xml")
+        property( "sonar.coverage.jacoco.xmlReportPaths", "build/reports/jacoco/jacocoTestReport/jacocoTestReport.xml")
     }
 }

--- a/vc-verifier/kotlin/vcverifier/build.gradle.kts
+++ b/vc-verifier/kotlin/vcverifier/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     `maven-publish`
     alias(libs.plugins.dokka)
     signing
+    id("org.sonarqube") version "6.0.1.5171"
 }
 
 android {


### PR DESCRIPTION
Add sonar analysis support for vc-verifier

- Code analysis
- Test coverage (configured via jacoco)

Report are available [here](https://sonarcloud.io/project/overview?id=mosip_vc-verifier)
snapshot - 
<img width="1399" alt="image" src="https://github.com/user-attachments/assets/7ce4630b-d562-4e8a-aeae-e36723dfbf24" />
