### PR TITLE
[INJIMOB-2712] add sonar job as push trigger

### DIFF
--- a/.github/workflows/push-trigger.yml
+++ b/.github/workflows/push-trigger.yml
@@ -36,7 +36,6 @@ jobs:
     uses: mosip/kattu/.github/workflows/gradlew-sonar-analysis.yml@master-java21
     with:
       SERVICE_LOCATION: vc-verifier/kotlin/vcverifier
-      ANDROID_LOCATION: ''
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       SONAR_ORGANIZATION: ${{ secrets.ORG_KEY }}

--- a/vc-verifier/kotlin/gradle/libs.versions.toml
+++ b/vc-verifier/kotlin/gradle/libs.versions.toml
@@ -18,6 +18,7 @@ lifecycleRuntimeKtx = "2.8.5"
 activityCompose = "1.9.2"
 composeBom = "2024.04.01"
 orgJson = "20240303"
+sonarqube = "5.1.0.4872"
 
 [libraries]
 junitJupiter = { group = "org.junit.jupiter", name = "junit-jupiter", version.ref = "junit" }
@@ -49,3 +50,4 @@ androidApplication = { id = "com.android.application", version.ref = "agp" }
 androidLibrary = { id = "com.android.library", version.ref = "agp" }
 jetbrainsKotlinAndroid = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
+sonarqube = { id = "org.sonarqube", version.ref = "sonarqube" }


### PR DESCRIPTION
Add sonar analysis support for vc-verifier

- Code analysis
- Test coverage (configured via jacoco)

Report are available [here](https://sonarcloud.io/project/overview?id=mosip_vc-verifier)
snapshot - 
<img width="1399" alt="image" src="https://github.com/user-attachments/assets/7ce4630b-d562-4e8a-aeae-e36723dfbf24" />
