### PR TITLE
[INJIMOB-2778] fix NoClassFoundException in mdoc verification - Java env

### DIFF
--- a/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/utils/Encoder.kt
+++ b/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/utils/Encoder.kt
@@ -5,19 +5,30 @@ import android.os.Build
 import java.util.Base64
 
 class Encoder {
-    @SuppressLint("NewApi")
     fun decodeFromBase64UrlFormatEncoded(content: String): ByteArray {
-        return if (BuildConfig.getVersionSDKInt() >= Build.VERSION_CODES.O) {
-            Base64.getUrlDecoder().decode(content.toByteArray())
-        } else {
-            var base64: String = content.replace('-', '+').replace('_', '/')
-            when (base64.length % 4) {
-                2 -> base64 += "=="
-                3 -> base64 += "="
-                else -> {}
+        return if (Util().isAndroid()) {
+            if( BuildConfig.getVersionSDKInt() >= Build.VERSION_CODES.O){
+                javaBase64UrlDecode(content)
+            } else {
+                androidBase64UrlDecode(content)
             }
-
-            return android.util.Base64.decode(base64, android.util.Base64.DEFAULT)
+        } else {
+            javaBase64UrlDecode(content)
         }
+    }
+
+    @SuppressLint("NewApi")
+    private fun javaBase64UrlDecode(content: String): ByteArray =
+        Base64.getUrlDecoder().decode(content.toByteArray())
+
+    private fun androidBase64UrlDecode(content: String): ByteArray {
+        var base64: String = content.replace('-', '+').replace('_', '/')
+        when (base64.length % 4) {
+            2 -> base64 += "=="
+            3 -> base64 += "="
+            else -> {}
+        }
+
+        return android.util.Base64.decode(base64, android.util.Base64.DEFAULT)
     }
 }

--- a/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/utils/Encoder.kt
+++ b/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/utils/Encoder.kt
@@ -6,7 +6,7 @@ import java.util.Base64
 
 class Encoder {
     fun decodeFromBase64UrlFormatEncoded(content: String): ByteArray {
-        return if (Util().isAndroid()) {
+        return if (Util.isAndroid()) {
             if( BuildConfig.getVersionSDKInt() >= Build.VERSION_CODES.O){
                 javaBase64UrlDecode(content)
             } else {

--- a/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/utils/Util.kt
+++ b/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/utils/Util.kt
@@ -11,6 +11,9 @@ import java.security.MessageDigest
 
 
 class Util {
+    fun isAndroid(): Boolean {
+        return System.getProperty("java.vm.name")?.contains("Dalvik") ?: false
+    }
 
     fun getId(obj: Any): String? {
         return when (obj) {

--- a/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/utils/Util.kt
+++ b/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/utils/Util.kt
@@ -11,8 +11,10 @@ import java.security.MessageDigest
 
 
 class Util {
-    fun isAndroid(): Boolean {
-        return System.getProperty("java.vm.name")?.contains("Dalvik") ?: false
+    companion object{
+        fun isAndroid(): Boolean {
+            return System.getProperty("java.vm.name")?.contains("Dalvik") ?: false
+        }
     }
 
     fun getId(obj: Any): String? {

--- a/vc-verifier/kotlin/vcverifier/src/test/java/io/mosip/vercred/vcverifier/utils/EncoderTest.kt
+++ b/vc-verifier/kotlin/vcverifier/src/test/java/io/mosip/vercred/vcverifier/utils/EncoderTest.kt
@@ -2,7 +2,6 @@ package io.mosip.vercred.vcverifier.utils
 
 import android.os.Build
 import io.mockk.every
-import io.mockk.mockkConstructor
 import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.unmockkAll
@@ -19,7 +18,7 @@ import org.junit.jupiter.api.Test
 class EncoderTest {
     @BeforeEach
     fun setUp() {
-        mockkConstructor(Util::class)
+        mockkObject(Util.Companion)
     }
 
     @AfterEach
@@ -31,7 +30,7 @@ class EncoderTest {
     inner class JavaEnvironment {
         @BeforeEach
         fun setUp() {
-            every { anyConstructed<Util>().isAndroid() } returns false
+            every { Util.isAndroid() } returns false
         }
 
         @Test
@@ -78,7 +77,7 @@ class EncoderTest {
     inner class AndroidEnvironment {
         @BeforeEach
         fun setUp() {
-            every { anyConstructed<Util>().isAndroid() } returns true
+            every { Util.isAndroid() } returns true
 
             mockkObject(BuildConfig)
 


### PR DESCRIPTION
for mdoc verification we perform base64 url decoding, this logic is android specific causing issues with Java environment. To resolve this issue, check is added if lib is running in android /Java environment and based on this decoding will be performed.