### PR TITLE
[INJIMOB-3102] update did web url parsing logic

### DIFF
--- a/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/DidWebResolver.kt
+++ b/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/DidWebResolver.kt
@@ -22,7 +22,7 @@ class DidWebResolver(private val didUrl: String) {
         private const val FRAGMENT = "(#.*)?"
         private val DID_MATCHER = "^did:$METHOD:$METHOD_ID$PARAMS$PATH$QUERY$FRAGMENT$".toRegex()
         private const val DOC_PATH = "/did.json"
-        private const val DID_WELL_KNOWN_PREFIX = ".well-known"
+        private const val DID_WELL_KNOWN_PREFIX = "/.well-known"
     }
 
     fun resolve(): Map<String, Any> {

--- a/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/DidWebResolver.kt
+++ b/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/DidWebResolver.kt
@@ -22,7 +22,7 @@ class DidWebResolver(private val didUrl: String) {
         private const val FRAGMENT = "(#.*)?"
         private val DID_MATCHER = "^did:$METHOD:$METHOD_ID$PARAMS$PATH$QUERY$FRAGMENT$".toRegex()
         private const val DOC_PATH = "/did.json"
-        private const val DID_WELL_KNOWN_PREFIX = "/.well-known"
+        private const val WELL_KNOWN_PATH = "/.well-known"
     }
 
     fun resolve(): Map<String, Any> {
@@ -41,7 +41,7 @@ class DidWebResolver(private val didUrl: String) {
         val baseDomain = idComponents.first()
         val path = idComponents.drop(1).joinToString("/")
         val urlPath = if (path.isEmpty()) {
-            DID_WELL_KNOWN_PREFIX+DOC_PATH
+            WELL_KNOWN_PATH + DOC_PATH
         } else {
             path + DOC_PATH
         }

--- a/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/DidWebResolver.kt
+++ b/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/DidWebResolver.kt
@@ -22,7 +22,7 @@ class DidWebResolver(private val didUrl: String) {
         private const val FRAGMENT = "(#.*)?"
         private val DID_MATCHER = "^did:$METHOD:$METHOD_ID$PARAMS$PATH$QUERY$FRAGMENT$".toRegex()
         private const val DOC_PATH = "/did.json"
-        private const val WELL_KNOWN_PATH = "/.well-known"
+        private const val WELL_KNOWN_PATH = ".well-known"
     }
 
     fun resolve(): Map<String, Any> {
@@ -40,13 +40,13 @@ class DidWebResolver(private val didUrl: String) {
         val idComponents = parsedDid.id.split(":").map { it }
         val baseDomain = idComponents.first()
         val path = idComponents.drop(1).joinToString("/")
-        
-        return if (path.isEmpty()){
-            "https://$baseDomain$WELL_KNOWN_PATH$DOC_PATH"
-        } else{
-            "https://$baseDomain/$path$DOC_PATH"
+        val urlPath = if (path.isEmpty()) {
+            WELL_KNOWN_PATH + DOC_PATH
+        } else {
+            path + DOC_PATH
         }
-        
+
+        return "https://$baseDomain/$urlPath"
     }
 
     private fun parseDidUrl(): ParsedDID {

--- a/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/DidWebResolver.kt
+++ b/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/DidWebResolver.kt
@@ -40,13 +40,13 @@ class DidWebResolver(private val didUrl: String) {
         val idComponents = parsedDid.id.split(":").map { it }
         val baseDomain = idComponents.first()
         val path = idComponents.drop(1).joinToString("/")
-        val urlPath = if (path.isEmpty()) {
-            WELL_KNOWN_PATH + DOC_PATH
-        } else {
-            path + DOC_PATH
+        
+        return if (path.isEmpty()){
+            "https://$baseDomain$WELL_KNOWN_PATH$DOC_PATH"
+        } else{
+            "https://$baseDomain/$path$DOC_PATH"
         }
-
-        return "https://$baseDomain/$urlPath"
+        
     }
 
     private fun parseDidUrl(): ParsedDID {

--- a/vc-verifier/kotlin/vcverifier/src/test/java/io/mosip/vercred/vcverifier/utils/DidWebResolverTest.kt
+++ b/vc-verifier/kotlin/vcverifier/src/test/java/io/mosip/vercred/vcverifier/utils/DidWebResolverTest.kt
@@ -52,9 +52,6 @@ class DidWebResolverTest {
         assertEquals("Given did url is not supported", exception.message)
     }
 
-    // New tests for URL resolution
-
-
     @Test
     fun `should resolve DID with only domain to well-known path`() {
         fun `resolve should return document when valid without path components`() {
@@ -75,7 +72,7 @@ class DidWebResolverTest {
 
     }
 
-        @Test
+    @Test
     fun `should resolve DID with multiple path components to correct URL`() {
         val didUrl = "did:web:example.com:user:alice"
         val mockResponse = mapOf("id" to didUrl)

--- a/vc-verifier/kotlin/vcverifier/src/test/java/io/mosip/vercred/vcverifier/utils/DidWebResolverTest.kt
+++ b/vc-verifier/kotlin/vcverifier/src/test/java/io/mosip/vercred/vcverifier/utils/DidWebResolverTest.kt
@@ -54,7 +54,7 @@ class DidWebResolverTest {
 
     @Test
     fun `should resolve DID with only domain to well-known path`() {
-        fun `resolve should return document when valid without path components`() {
+        
             val didUrl = "did:web:example.com"
             val mockResponse = mapOf("id" to didUrl)
 
@@ -67,8 +67,7 @@ class DidWebResolverTest {
             } returns mockResponse
 
             val resolvedDoc = DidWebResolver(didUrl).resolve()
-            assertEquals(resolvedDoc, mapOf("id" to didUrl))
-        }
+            assertEquals(resolvedDoc, mapOf("id" to didUrl))    
 
     }
 


### PR DESCRIPTION
This update enhances the DID resolver by implementing logic for appending /.well-known based on the structure of the did:web identifier. It correctly resolves did:web:example.com to https://example.com/.well-known/did.json when only a domain name is present, and did:web:example.com:user:alice to https://example.com/user/alice/did.json when path components are included