### PR TITLE
[INJIMOB-3459] refactor: modify SignatureVerifier verify signature

### DIFF
--- a/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/signature/SignatureVerifier.kt
+++ b/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/signature/SignatureVerifier.kt
@@ -1,7 +1,15 @@
 package io.mosip.vercred.vcverifier.signature
 
+import org.bouncycastle.jce.provider.BouncyCastleProvider
 import java.security.PublicKey
 
+internal var bouncyCastleProvider: BouncyCastleProvider = BouncyCastleProvider()
+
 interface SignatureVerifier {
-    fun verify(publicKey: PublicKey, signData: ByteArray, signature: ByteArray?): Boolean
+    fun verify(
+        publicKey: PublicKey,
+        signData: ByteArray,
+        signature: ByteArray?,
+        provider: BouncyCastleProvider? = bouncyCastleProvider
+    ): Boolean
 }

--- a/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/signature/impl/CoseSignatureVerifierImpl.kt
+++ b/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/signature/impl/CoseSignatureVerifierImpl.kt
@@ -4,13 +4,15 @@ import com.android.identity.internal.Util
 import io.mosip.vercred.vcverifier.exception.SignatureVerificationException
 import io.mosip.vercred.vcverifier.signature.SignatureVerifier
 import io.mosip.vercred.vcverifier.utils.CborDataItemUtils
+import org.bouncycastle.jce.provider.BouncyCastleProvider
 import java.security.PublicKey
 
 class CoseSignatureVerifierImpl: SignatureVerifier {
     override fun verify(
         publicKey: PublicKey,
         signData: ByteArray,
-        signature: ByteArray?
+        signature: ByteArray?,
+        provider: BouncyCastleProvider?
     ): Boolean {
         val coseSign1 = CborDataItemUtils.fromByteArray(signData)
         val coseSign1CheckSignature =

--- a/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/signature/impl/ED25519SignatureVerifierImpl.kt
+++ b/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/signature/impl/ED25519SignatureVerifierImpl.kt
@@ -3,11 +3,10 @@ package io.mosip.vercred.vcverifier.signature.impl
 import io.mosip.vercred.vcverifier.signature.SignatureVerifier
 import io.mosip.vercred.vcverifier.constants.CredentialVerifierConstants
 import io.mosip.vercred.vcverifier.exception.SignatureVerificationException
+import io.mosip.vercred.vcverifier.signature.bouncyCastleProvider
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 import java.security.PublicKey
 import java.security.Signature
-
-private var provider: BouncyCastleProvider = BouncyCastleProvider()
 
 class ED25519SignatureVerifierImpl : SignatureVerifier {
 
@@ -15,9 +14,10 @@ class ED25519SignatureVerifierImpl : SignatureVerifier {
         publicKey: PublicKey,
         signData: ByteArray,
         signature: ByteArray?,
+        provider: BouncyCastleProvider?,
     ): Boolean {
         try {
-                Signature.getInstance(CredentialVerifierConstants.ED25519_ALGORITHM, provider)
+                Signature.getInstance(CredentialVerifierConstants.ED25519_ALGORITHM, provider ?: bouncyCastleProvider )
                     .apply {
                     initVerify(publicKey)
                     update(signData)

--- a/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/signature/impl/ES256KSignatureVerifierImpl.kt
+++ b/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/signature/impl/ES256KSignatureVerifierImpl.kt
@@ -3,6 +3,7 @@ package io.mosip.vercred.vcverifier.signature.impl
 import io.mosip.vercred.vcverifier.constants.CredentialVerifierConstants
 import io.mosip.vercred.vcverifier.exception.SignatureVerificationException
 import io.mosip.vercred.vcverifier.signature.SignatureVerifier
+import io.mosip.vercred.vcverifier.signature.bouncyCastleProvider
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 import java.io.ByteArrayOutputStream
 import java.math.BigInteger
@@ -10,13 +11,13 @@ import java.security.PublicKey
 import java.security.Signature
 
 private const val ECDSA_SIGNATURE_LENGTH = 64
-private var provider: BouncyCastleProvider = BouncyCastleProvider()
 
 class ES256KSignatureVerifierImpl : SignatureVerifier {
     override fun verify(
         publicKey: PublicKey,
         signData: ByteArray,
-        signature: ByteArray?
+        signature: ByteArray?,
+        provider: BouncyCastleProvider?
     ): Boolean {
         if (signature == null || signature.size != ECDSA_SIGNATURE_LENGTH) {
             throw SignatureVerificationException("Invalid signature length: Expected 64 bytes for R || S format")
@@ -25,7 +26,10 @@ class ES256KSignatureVerifierImpl : SignatureVerifier {
         try {
             val derSignature = convertRawSignatureToDER(signature) // Convert to ASN.1 DER
 
-            Signature.getInstance(CredentialVerifierConstants.EC_ALGORITHM, provider)
+            Signature.getInstance(
+                CredentialVerifierConstants.EC_ALGORITHM,
+                provider ?: bouncyCastleProvider
+            )
                 .apply {
                     initVerify(publicKey)
                     update(signData)

--- a/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/signature/impl/PS256SignatureVerifierImpl.kt
+++ b/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/signature/impl/PS256SignatureVerifierImpl.kt
@@ -3,6 +3,7 @@ package io.mosip.vercred.vcverifier.signature.impl
 import io.mosip.vercred.vcverifier.signature.SignatureVerifier
 import io.mosip.vercred.vcverifier.constants.CredentialVerifierConstants
 import io.mosip.vercred.vcverifier.exception.SignatureVerificationException
+import org.bouncycastle.jce.provider.BouncyCastleProvider
 import java.security.PublicKey
 import java.security.Signature
 import java.security.spec.MGF1ParameterSpec
@@ -14,6 +15,7 @@ class PS256SignatureVerifierImpl : SignatureVerifier {
         publicKey: PublicKey,
         signData: ByteArray,
         signature: ByteArray?,
+        provider: BouncyCastleProvider?,
     ): Boolean {
         try {
             val psSignature: Signature =

--- a/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/signature/impl/RS256SignatureVerifierImpl.kt
+++ b/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/signature/impl/RS256SignatureVerifierImpl.kt
@@ -3,20 +3,23 @@ package io.mosip.vercred.vcverifier.signature.impl
 import io.mosip.vercred.vcverifier.signature.SignatureVerifier
 import io.mosip.vercred.vcverifier.constants.CredentialVerifierConstants
 import io.mosip.vercred.vcverifier.exception.SignatureVerificationException
+import io.mosip.vercred.vcverifier.signature.bouncyCastleProvider
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 import java.security.PublicKey
 import java.security.Signature
-
-private var provider: BouncyCastleProvider = BouncyCastleProvider()
 
 class RS256SignatureVerifierImpl : SignatureVerifier {
     override fun verify(
         publicKey: PublicKey,
         signData: ByteArray,
         signature: ByteArray?,
+        provider: BouncyCastleProvider?,
     ): Boolean {
         try {
-            Signature.getInstance(CredentialVerifierConstants.RS256_ALGORITHM, provider)
+            Signature.getInstance(
+                CredentialVerifierConstants.RS256_ALGORITHM,
+                provider ?: bouncyCastleProvider
+            )
                 .apply {
                     initVerify(publicKey)
                     update(signData)


### PR DESCRIPTION
for backward compatibility SignatureVerifier verify method
1. accepts provider optionally, consumer can send it or not