### PR TITLE
[INJIMOB-3517]: [Release-1.5.x]Aligning the standard for date time handling with spec

### DIFF
--- a/vc-verifier/kotlin/gradle/libs.versions.toml
+++ b/vc-verifier/kotlin/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ bouncyCastle = "1.70"
 jsonldCommonJava = "1.8.0"
 nimbusJoseJwt = "9.40"
 springWeb = "5.0.20.RELEASE"
+threetenabp = "1.4.9"
 titaniumJsonLd = "1.3.1"
 okHttp = "4.1.0"
 dokka = "1.9.20"
@@ -32,6 +33,7 @@ junitJupiter = { group = "org.junit.jupiter", name = "junit-jupiter", version.re
 authelete-sd-jwt = { group = "com.authlete", name = "sd-jwt", version.ref = "authleteSdJwt" }
 mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
 ldSignaturesJava = { group = "info.weboftrust", name = "ld-signatures-java", version.ref = "ldSignaturesJava" }
+threetenabp = { module = "com.jakewharton.threetenabp:threetenabp", version.ref = "threetenabp" }
 titaniumJsonLd = { group = "com.apicatalog", name = "titanium-json-ld-jre8", version.ref = "titaniumJsonLd" }
 okHttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okHttp" }
 bouncyCastle = { group = "org.bouncycastle", name = "bcprov-jdk15to18", version.ref = "bouncyCastle" }

--- a/vc-verifier/kotlin/vcverifier/build.gradle.kts
+++ b/vc-verifier/kotlin/vcverifier/build.gradle.kts
@@ -68,6 +68,8 @@ dependencies {
     testImplementation(libs.mockk)
     testImplementation(libs.junitJupiter)
     testImplementation(libs.mockWebServer)
+    implementation(libs.threetenabp)
+
 }
 
 tasks.withType<Test> {

--- a/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/credentialverifier/validator/SdJwtValidator.kt
+++ b/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/credentialverifier/validator/SdJwtValidator.kt
@@ -32,10 +32,10 @@ import io.mosip.vercred.vcverifier.data.ValidationStatus
 import io.mosip.vercred.vcverifier.exception.ValidationException
 import io.mosip.vercred.vcverifier.utils.Base64Decoder
 import io.mosip.vercred.vcverifier.utils.DateUtils
+import io.mosip.vercred.vcverifier.utils.DateUtils.formatEpochSecondsToIsoUtc
 import io.mosip.vercred.vcverifier.utils.Util.isValidUri
 import org.json.JSONArray
 import org.json.JSONObject
-import java.util.Date
 
 class SdJwtValidator {
     companion object {
@@ -163,7 +163,7 @@ class SdJwtValidator {
 
     private fun validateTimeClaims(payload: JSONObject) {
         payload.optLong("iat", -1).takeIf { it > 0 }?.let { iat ->
-            if (DateUtils.isFutureDateWithTolerance(Date(iat * 1000).toString())) {
+            if (DateUtils.isFutureDateWithTolerance(formatEpochSecondsToIsoUtc(iat))) {
                 throw ValidationException(
                     ERROR_CURRENT_DATE_BEFORE_ISSUANCE_DATE,
                     ERROR_CODE_CURRENT_DATE_BEFORE_ISSUANCE_DATE
@@ -172,7 +172,7 @@ class SdJwtValidator {
         }
 
         payload.optLong("nbf", -1).takeIf { it > 0 }?.let { nbf ->
-            if (DateUtils.isFutureDateWithTolerance(Date(nbf * 1000).toString())) {
+            if (DateUtils.isFutureDateWithTolerance(formatEpochSecondsToIsoUtc(nbf))) {
                 throw ValidationException(
                     ERROR_CURRENT_DATE_BEFORE_PROCESSING_DATE,
                     ERROR_CODE_CURRENT_DATE_BEFORE_PROCESSING_DATE
@@ -181,7 +181,7 @@ class SdJwtValidator {
         }
 
         payload.optLong("exp", -1).takeIf { it > 0 }?.let { exp ->
-            if (DateUtils.isVCExpired(Date(exp * 1000).toString())) {
+            if (DateUtils.isVCExpired(formatEpochSecondsToIsoUtc(exp))) {
                 throw ValidationException(ERROR_MESSAGE_VC_EXPIRED, ERROR_CODE_VC_EXPIRED)
             }
         }

--- a/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/utils/DateUtils.kt
+++ b/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/utils/DateUtils.kt
@@ -16,38 +16,37 @@ import io.mosip.vercred.vcverifier.constants.CredentialValidatorConstants.VALID_
 import io.mosip.vercred.vcverifier.constants.CredentialValidatorConstants.VALID_UNTIL
 import io.mosip.vercred.vcverifier.exception.ValidationException
 import org.json.JSONObject
-import java.text.SimpleDateFormat
+import org.threeten.bp.Instant
+import org.threeten.bp.LocalDateTime
+import org.threeten.bp.OffsetDateTime
+import org.threeten.bp.ZoneOffset
+import org.threeten.bp.format.DateTimeFormatter
 import java.util.Date
-import java.util.Locale
-import java.util.TimeZone
 import java.util.logging.Logger
 
 object DateUtils {
 
     private val logger = Logger.getLogger(DateUtils::class.java.name)
 
-    private val dateFormats = listOf(
-        ("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"),
-        ("yyyy-MM-dd'T'HH:mm:ss'Z'")
-    )
+    private val formatterWithOffset: DateTimeFormatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME
+    private val formatterLocal: DateTimeFormatter = DateTimeFormatter.ISO_LOCAL_DATE_TIME
 
-    private const val UTC = "UTC"
-
-    fun isValidDate(dateValue: String): Boolean {
-        return DATE_REGEX.matches(dateValue)
+    fun isValidDate(dateString: String): Boolean {
+        return parseDate(dateString) != null
     }
 
-    fun parseDate(date: String): Date? {
-        dateFormats.forEach {
+    fun parseDate(dateString: String): Date? {
+        return try {
+            val offsetDateTime = OffsetDateTime.parse(dateString, formatterWithOffset)
+            Date(offsetDateTime.toInstant().toEpochMilli())
+        } catch (e: Exception) {
             try {
-                val format = SimpleDateFormat(it, Locale.getDefault()).apply {
-                    timeZone = TimeZone.getTimeZone(UTC)
-                }
-                return format.parse(date)
+                val localDateTime = LocalDateTime.parse(dateString, formatterLocal)
+                Date(localDateTime.toInstant(ZoneOffset.UTC).toEpochMilli())
             } catch (_: Exception) {
+                null
             }
         }
-        return null
     }
 
     fun validateV1DateFields(vcJsonObject: JSONObject) {
@@ -98,10 +97,7 @@ object DateUtils {
 
     fun isFutureDateWithTolerance(inputDateString: String, toleranceInMilliSeconds: Long = 3000): Boolean {
         val inputDate: Date? = try {
-            parseDate(inputDateString) ?: run {
-                val localFormat = SimpleDateFormat("EEE MMM dd HH:mm:ss zzz yyyy", Locale.ENGLISH)
-                localFormat.parse(inputDateString)
-            }
+            parseDate(inputDateString)
         } catch (e: Exception) {
             logger.severe("Given date is not available in supported date formats")
             return false
@@ -115,6 +111,12 @@ object DateUtils {
 
         val upperBound = currentTime + toleranceInMilliSeconds
         return inputDateTime > upperBound
+    }
+
+    fun formatEpochSecondsToIsoUtc(epochSeconds: Long): String {
+        val odt = OffsetDateTime.ofInstant(Instant.ofEpochSecond(epochSeconds), ZoneOffset.UTC)
+        println(odt)
+        return odt.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
     }
 
 }

--- a/vc-verifier/kotlin/vcverifier/src/test/java/io/mosip/vercred/vcverifier/utils/DateUtilsTest.kt
+++ b/vc-verifier/kotlin/vcverifier/src/test/java/io/mosip/vercred/vcverifier/utils/DateUtilsTest.kt
@@ -1,0 +1,134 @@
+package io.mosip.vercred.vcverifier.utils
+
+import io.mosip.vercred.vcverifier.utils.DateUtils.parseDate
+import io.mosip.vercred.vcverifier.utils.DateUtils.isValidDate
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+
+
+class DateUtilsTest {
+
+    @Test
+    fun testBasicUtcDate() {
+        val date = parseDate("2025-09-17T10:15:30Z")
+        assertNotNull(date)
+        assertEquals(1758104130000L, date?.time)
+    }
+
+    @Test
+    fun testFractionalSecondsMillis() {
+        val date = parseDate("2025-09-17T10:15:30.123Z")
+        assertNotNull(date)
+        assertEquals(1758104130123L, date?.time)
+    }
+
+    @Test
+    fun testFractionalSecondsNanoTruncated() {
+        val date = parseDate("2025-09-17T10:15:30.123456789Z")
+        assertNotNull(date)
+        assertEquals(1758104130123, date?.time)
+    }
+
+    @Test
+    fun testWithPositiveOffset() {
+        val utc = parseDate("2025-09-17T10:15:30Z")
+        val offset = parseDate("2025-09-17T15:45:30+05:30")
+        assertNotNull(offset)
+        assertEquals(utc?.time, offset?.time)
+    }
+
+    @Test
+    fun testWithNegativeOffset() {
+        val utc = parseDate("2025-09-17T10:15:30Z")
+        val offset = parseDate("2025-09-17T06:15:30-04:00")
+        assertNotNull(offset)
+        assertEquals(utc?.time, offset?.time)
+    }
+
+    @Test
+    fun testNoTimezoneTreatedAsUTC() {
+        val date = parseDate("2025-09-17T10:15:30")
+        val utc = parseDate("2025-09-17T10:15:30Z")
+        assertNotNull(date)
+        assertEquals(utc?.time, date?.time)
+    }
+
+    @Test
+    fun testLeapYearValid() {
+        val date = parseDate("2024-02-29T12:00:00Z")
+        assertNotNull(date)
+    }
+
+    @Test
+    fun testFractionalSingleDigit() {
+        val date = parseDate("2025-09-17T10:15:30.1Z")
+        assertNotNull(date)
+        assertEquals(1758104130100L, date?.time)
+    }
+
+    @Test
+    fun testFractionalMaxDigits() {
+        val date = parseDate("2025-09-17T10:15:30.987654321Z")
+        assertNotNull(date)
+        assertEquals(1758104130987, date?.time)
+    }
+
+    @Test
+    fun testBoundaryOffsetEqualsUtc() {
+        val utc = parseDate("2025-09-17T10:15:30Z")
+        val offset = parseDate("2025-09-17T10:15:30+00:00")
+        assertNotNull(offset)
+        assertEquals(utc?.time, offset?.time)
+    }
+
+
+    @Test
+    fun testMalformedString_missing_T() {
+        assertNull(parseDate("2025-09-17 10:15:30"))
+    }
+
+    @Test
+    fun testInvalidMonth() {
+        assertNull(parseDate("2025-13-01T10:15:30Z"))
+    }
+
+    @Test
+    fun testInvalidDay() {
+        assertNull(parseDate("2025-09-31T10:15:30Z"))
+    }
+
+    @Test
+    fun testEmptyString() {
+        assertNull(parseDate(""))
+    }
+
+    @Test
+    fun testNonsenseString() {
+        assertNull(parseDate("not-a-date"))
+    }
+
+    @Test
+    fun testLeapYearInvalid() {
+        assertNull(parseDate("2023-02-29T12:00:00Z"))
+    }
+
+
+    @Test
+    fun testIsValidTrue() {
+        assertTrue(isValidDate("2025-09-17T10:15:30Z"))
+        assertTrue(isValidDate("2025-09-17T10:15:30.123456+05:30"))
+        assertTrue(isValidDate("2025-09-17T10:15:30"))
+    }
+
+    @Test
+    fun testIsValidFalse() {
+        assertFalse(isValidDate(""))
+        assertFalse(isValidDate("not-a-date"))
+        assertFalse(isValidDate("2025-09-17 10:15:30"))
+        assertFalse(isValidDate("2023-02-29T12:00:00Z"))
+    }
+}

--- a/vc-verifier/kotlin/vcverifier/src/test/java/io/mosip/vercred/vcverifier/utils/UtilsTest.kt
+++ b/vc-verifier/kotlin/vcverifier/src/test/java/io/mosip/vercred/vcverifier/utils/UtilsTest.kt
@@ -6,6 +6,9 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import org.threeten.bp.OffsetDateTime
+import org.threeten.bp.ZoneOffset
+import org.threeten.bp.format.DateTimeFormatter
 import java.io.ByteArrayOutputStream
 import java.util.Date
 
@@ -171,8 +174,9 @@ class UtilsTest {
 
     @Test
     fun `test when issuanceDate time is future date time but outside tolerance range`() {
-        val currentDate = Date()
-        val issuanceDate = Date(currentDate.time + 5000).toString()
+        val currentDateTime = OffsetDateTime.now(ZoneOffset.UTC)
+        val futureDateTime = currentDateTime.plusSeconds(5)
+        val issuanceDate = futureDateTime.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
 
         val result = dateUtils.isFutureDateWithTolerance(issuanceDate)
         assertTrue(result)


### PR DESCRIPTION
- Using `threetenabp` library to parse the date to align with standard by removing the manual parsing