### PR TITLE
[INJIVER-1531] Added verifyV2() and verifyAndGetCredentialStatusV2() in PresentationVerifier 

### DIFF
--- a/vc-verifier/kotlin/vcverifier/publish-artifact.gradle
+++ b/vc-verifier/kotlin/vcverifier/publish-artifact.gradle
@@ -96,7 +96,7 @@ publishing {
             }
             groupId = "io.inji"
             artifactId = "vcverifier-aar"
-            version = "1.7.0-RC3"
+            version = "1.7.0-RC4"
             if (project.gradle.startParameter.taskNames.any { it.contains('assembleRelease') }) {
                 artifacts {
                     aar {
@@ -110,7 +110,7 @@ publishing {
             artifact(tasks.named("jarRelease").get())
             groupId = "io.inji"
             artifactId = "vcverifier-jar"
-            version = "1.7.0-RC3"
+            version = "1.7.0-RC4"
             artifact(tasks.named("javadocJar").get())
             artifact(tasks.named("sourcesJar").get())
             pom {

--- a/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/PresentationVerifier.kt
+++ b/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/PresentationVerifier.kt
@@ -120,14 +120,20 @@ class PresentationVerifier {
                     "SIGNATURE_VERIFICATION_FAILED"
                 )
             }
-        } catch (e: PublicKeyNotFoundException) {
-            VerificationResult(false, e.message ?: "Public key not found", "PUBLIC_KEY_NOT_FOUND")
-        } catch (e: UnsupportedDidUrl) {
-            VerificationResult(false, e.message ?: "Unsupported DID", "UNSUPPORTED_DID")
-        } catch (e: SignatureVerificationException) {
-            VerificationResult(false, e.message ?: "Signature verification error", "SIGNATURE_VERIFICATION_EXCEPTION")
-        } catch (e: RuntimeException) {
-            VerificationResult(false, "Unsupported VP token type", "VP_UNSUPPORTED_FORMAT")
+        } catch (e: Exception) {
+            logger.severe("Error while verifying presentation proof: ${e.message}")
+            when (e) {
+                is PublicKeyNotFoundException,
+                is IllegalStateException,
+                is UnsupportedDidUrl,
+                is InvalidKeySpecException,
+                is SignatureNotSupportedException,
+                is SignatureVerificationException -> throw e
+
+                else -> {
+                    throw UnknownException("Error while doing verification of verifiable presentation")
+                }
+            }
         }
     }
     private fun verifyPresentationProof(vcJsonLdObject: JsonLDObject): Boolean {

--- a/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/PresentationVerifier.kt
+++ b/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/PresentationVerifier.kt
@@ -14,8 +14,12 @@ import io.mosip.vercred.vcverifier.constants.CredentialVerifierConstants.JSON_WE
 import io.mosip.vercred.vcverifier.constants.Shared
 import io.mosip.vercred.vcverifier.data.PresentationVerificationResult
 import io.mosip.vercred.vcverifier.data.PresentationResultWithCredentialStatus
+import io.mosip.vercred.vcverifier.data.PresentationResultWithCredentialStatusV2
+import io.mosip.vercred.vcverifier.data.PresentationVerificationResultV2
 import io.mosip.vercred.vcverifier.data.VCResult
+import io.mosip.vercred.vcverifier.data.VCResultV2
 import io.mosip.vercred.vcverifier.data.VCResultWithCredentialStatus
+import io.mosip.vercred.vcverifier.data.VCResultWithCredentialStatusV2
 import io.mosip.vercred.vcverifier.data.VPVerificationStatus
 import io.mosip.vercred.vcverifier.data.VerificationResult
 import io.mosip.vercred.vcverifier.data.VerificationStatus
@@ -50,9 +54,18 @@ class PresentationVerifier {
         return PresentationVerificationResult(presentationVerificationStatus, vcVerificationResults)
     }
 
+    fun verifyV2(presentation: String): PresentationVerificationResultV2 {
+
+        val presentationVerificationStatus: VerificationResult = getPresentationVerificationStatusV2(presentation)
+
+        val verifiableCredentials = JSONObject(presentation).getJSONArray(Shared.KEY_VERIFIABLE_CREDENTIAL)
+        val vcVerificationResults: List<VCResultV2> = getVCVerificationResultsV2(verifiableCredentials)
+
+        return PresentationVerificationResultV2(presentationVerificationStatus, vcVerificationResults)
+    }
+
     private fun getPresentationVerificationStatus(presentation: String): VPVerificationStatus {
         logger.info("Received Presentation For Verification - Start")
-        val proofVerificationStatus: VPVerificationStatus
         val vcJsonLdObject: JsonLDObject
 
         try {
@@ -61,65 +74,11 @@ class PresentationVerifier {
             throw PresentationNotSupportedException("Unsupported VP Token type")
         }
 
-        try {
-            logger.info("Proof verification - Start")
-            vcJsonLdObject.documentLoader = Util.getConfigurableDocumentLoader()
-            val ldProof: LdProof = LdProof.getFromJsonLDObject(vcJsonLdObject)
-
-            val canonicalHashBytes = URDNA2015Canonicalizer().canonicalize(ldProof, vcJsonLdObject)
-
-            val verificationMethod = ldProof.verificationMethod
-            val publicKeyObj = PublicKeyResolverFactory().get(verificationMethod)
-
-            when {
-                ldProof.type == ED25519_PROOF_TYPE_2018 && !ldProof.jws.isNullOrEmpty() -> {
-                    val signJWS: String = ldProof.jws
-                    val jwsObject = JWSObject.parse(signJWS)
-                    val signature = jwsObject.signature.decode()
-                    val actualData =
-                        JWSUtil.getJwsSigningInput(jwsObject.header, canonicalHashBytes)
-                    proofVerificationStatus = if (ED25519SignatureVerifierImpl().verify(
-                            publicKeyObj,
-                            actualData,
-                            signature
-                        )
-                    ) VPVerificationStatus.VALID else VPVerificationStatus.INVALID
-                }
-
-                ldProof.type == ED25519_PROOF_TYPE_2020 && !ldProof.proofValue.isNullOrEmpty() -> {
-                    val proofValue = ldProof.proofValue
-                    val signature = Multibase.decode(proofValue)
-                    proofVerificationStatus = if (ED25519SignatureVerifierImpl().verify(
-                            publicKeyObj,
-                            canonicalHashBytes,
-                            signature
-                        )
-                    ) VPVerificationStatus.VALID else VPVerificationStatus.INVALID
-                }
-
-                ldProof.type == JSON_WEB_PROOF_TYPE_2020 && !ldProof.jws.isNullOrEmpty() -> {
-                    val signJWS: String = ldProof.jws
-                    val jwsObject = JWSObject.parse(signJWS)
-                    if (jwsObject.header.algorithm != JWSAlgorithm.EdDSA) throw SignatureNotSupportedException(
-                        "Unsupported jws signature algorithm"
-                    )
-                    val signature = jwsObject.signature.decode()
-                    val actualData =
-                        JWSUtil.getJwsSigningInput(jwsObject.header, canonicalHashBytes)
-
-                    proofVerificationStatus = if (ED25519SignatureVerifierImpl().verify(
-                            publicKeyObj,
-                            actualData,
-                            signature
-                        )
-                    ) VPVerificationStatus.VALID else VPVerificationStatus.INVALID
-                }
-
-                else -> {
-                    proofVerificationStatus = VPVerificationStatus.INVALID
-                }
-            }
-
+        return try {
+            if (verifyPresentationProof(vcJsonLdObject))
+                VPVerificationStatus.VALID
+            else
+                VPVerificationStatus.INVALID
         } catch (e: Exception) {
             logger.severe("Error while verifying presentation proof: ${e.message}")
             when (e) {
@@ -135,7 +94,92 @@ class PresentationVerifier {
                 }
             }
         }
-        return proofVerificationStatus
+    }
+    private fun getPresentationVerificationStatusV2(presentation: String): VerificationResult {
+        logger.info("Received Presentation For Verification - Start")
+        val vcJsonLdObject: JsonLDObject
+
+        try {
+            vcJsonLdObject = JsonLDObject.fromJson(presentation)
+        } catch (e: RuntimeException) {
+            throw PresentationNotSupportedException("Unsupported VP Token type")
+        }
+        return try {
+            val isVerified = verifyPresentationProof(vcJsonLdObject)
+
+            if (isVerified) {
+                VerificationResult(
+                    true,
+                    "Presentation proof verification successful",
+                    "SUCCESS"
+                )
+            } else {
+                VerificationResult(
+                    false,
+                    "Signature verification failed",
+                    "SIGNATURE_VERIFICATION_FAILED"
+                )
+            }
+        } catch (e: PublicKeyNotFoundException) {
+            VerificationResult(false, e.message ?: "Public key not found", "PUBLIC_KEY_NOT_FOUND")
+        } catch (e: UnsupportedDidUrl) {
+            VerificationResult(false, e.message ?: "Unsupported DID", "UNSUPPORTED_DID")
+        } catch (e: SignatureVerificationException) {
+            VerificationResult(false, e.message ?: "Signature verification error", "SIGNATURE_VERIFICATION_EXCEPTION")
+        } catch (e: RuntimeException) {
+            VerificationResult(false, "Unsupported VP token type", "VP_UNSUPPORTED_FORMAT")
+        }
+    }
+    private fun verifyPresentationProof(vcJsonLdObject: JsonLDObject): Boolean {
+
+        vcJsonLdObject.documentLoader = Util.getConfigurableDocumentLoader()
+        val ldProof = LdProof.getFromJsonLDObject(vcJsonLdObject)
+
+        val canonicalHashBytes =
+            URDNA2015Canonicalizer().canonicalize(ldProof, vcJsonLdObject)
+
+        val publicKey =
+            PublicKeyResolverFactory().get(ldProof.verificationMethod)
+
+        return when {
+            ldProof.type == ED25519_PROOF_TYPE_2018 && !ldProof.jws.isNullOrEmpty() -> {
+                val jws = JWSObject.parse(ldProof.jws)
+                val actualData =
+                    JWSUtil.getJwsSigningInput(jws.header, canonicalHashBytes)
+
+                ED25519SignatureVerifierImpl().verify(
+                    publicKey,
+                    actualData,
+                    jws.signature.decode()
+                )
+            }
+
+            ldProof.type == ED25519_PROOF_TYPE_2020 && !ldProof.proofValue.isNullOrEmpty() -> {
+                ED25519SignatureVerifierImpl().verify(
+                    publicKey,
+                    canonicalHashBytes,
+                    Multibase.decode(ldProof.proofValue)
+                )
+            }
+
+            ldProof.type == JSON_WEB_PROOF_TYPE_2020 && !ldProof.jws.isNullOrEmpty() -> {
+                val jws = JWSObject.parse(ldProof.jws)
+                if (jws.header.algorithm != JWSAlgorithm.EdDSA) {
+                    throw SignatureNotSupportedException("Unsupported JWS algorithm")
+                }
+
+                val actualData =
+                    JWSUtil.getJwsSigningInput(jws.header, canonicalHashBytes)
+
+                ED25519SignatureVerifierImpl().verify(
+                    publicKey,
+                    actualData,
+                    jws.signature.decode()
+                )
+            }
+
+            else -> false
+        }
     }
 
     private fun getVCVerificationResults(verifiableCredentials: JSONArray): List<VCResult> {
@@ -159,6 +203,25 @@ class PresentationVerifier {
         }
     }
 
+    private fun getVCVerificationResultsV2(verifiableCredentials: JSONArray): List<VCResultV2> {
+        return verifiableCredentials.asIterable().map { item ->
+            val verificationResult: VerificationResult =
+                credentialsVerifier.verify((item as JSONObject).toString(), CredentialFormat.LDP_VC)
+
+            /*
+            Here we are adding the entire VC as a string in the method response. We know that this is not very efficient.
+            But in newer draft of OpenId4VP specifications the Presentation Exchange
+            is fully removed so we rather not use the submission_requirements for giving the VC reference
+            for response. As of now we could not find anything unique that can be referred in a vp_token
+            VC we will be going with the approach of sending whole VC back in response.
+            */
+            VCResultV2(
+                item.toString(),
+                verificationResult
+            )
+        }
+    }
+
     private fun getVCVerificationResultsWithCredentialStatus(verifiableCredentials: JSONArray, statusPurposeList: List<String>): List<VCResultWithCredentialStatus> {
         return verifiableCredentials.asIterable().map { item ->
             val credentialVerificationSummary = credentialsVerifier.verifyAndGetCredentialStatus((item as JSONObject).toString(), CredentialFormat.LDP_VC, statusPurposeList)
@@ -167,6 +230,16 @@ class PresentationVerifier {
             val credentialStatus = credentialVerificationSummary.credentialStatus
 
             VCResultWithCredentialStatus(item.toString(), singleVCVerification, credentialStatus)
+        }
+    }
+
+    private fun getVCVerificationResultsWithCredentialStatusV2(verifiableCredentials: JSONArray, statusPurposeList: List<String>): List<VCResultWithCredentialStatusV2> {
+        return verifiableCredentials.asIterable().map { item ->
+            val credentialVerificationSummary = credentialsVerifier.verifyAndGetCredentialStatus((item as JSONObject).toString(), CredentialFormat.LDP_VC, statusPurposeList)
+            val verificationResult: VerificationResult = credentialVerificationSummary.verificationResult
+            val credentialStatus = credentialVerificationSummary.credentialStatus
+
+            VCResultWithCredentialStatusV2(item.toString(), verificationResult, credentialStatus)
         }
     }
 
@@ -180,6 +253,18 @@ class PresentationVerifier {
         val vcVerificationResults: List<VCResultWithCredentialStatus> = getVCVerificationResultsWithCredentialStatus(verifiableCredentials, statusPurposeList)
 
         return PresentationResultWithCredentialStatus(presentationVerificationStatus, vcVerificationResults)
+    }
+
+    fun verifyAndGetCredentialStatusV2(
+        presentation: String,
+        statusPurposeList: List<String> = emptyList()
+    ): PresentationResultWithCredentialStatusV2 {
+        val presentationVerificationStatus = getPresentationVerificationStatusV2(presentation)
+
+        val verifiableCredentials = JSONObject(presentation).getJSONArray(Shared.KEY_VERIFIABLE_CREDENTIAL)
+        val vcVerificationResults: List<VCResultWithCredentialStatusV2> = getVCVerificationResultsWithCredentialStatusV2(verifiableCredentials, statusPurposeList)
+
+        return PresentationResultWithCredentialStatusV2(presentationVerificationStatus, vcVerificationResults)
     }
 }
 

--- a/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/PresentationVerifier.kt
+++ b/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/PresentationVerifier.kt
@@ -56,12 +56,12 @@ class PresentationVerifier {
 
     fun verifyV2(presentation: String): PresentationVerificationResultV2 {
 
-        val presentationVerificationStatus: VerificationResult = getPresentationVerificationStatusV2(presentation)
+        val presentationVerificationResult: VerificationResult = getPresentationVerificationStatusV2(presentation)
 
         val verifiableCredentials = JSONObject(presentation).getJSONArray(Shared.KEY_VERIFIABLE_CREDENTIAL)
         val vcVerificationResults: List<VCResultV2> = getVCVerificationResultsV2(verifiableCredentials)
 
-        return PresentationVerificationResultV2(presentationVerificationStatus, vcVerificationResults)
+        return PresentationVerificationResultV2(presentationVerificationResult, vcVerificationResults)
     }
 
     private fun getPresentationVerificationStatus(presentation: String): VPVerificationStatus {

--- a/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/PresentationVerifier.kt
+++ b/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/PresentationVerifier.kt
@@ -110,14 +110,14 @@ class PresentationVerifier {
             if (isVerified) {
                 VerificationResult(
                     true,
-                    "Presentation proof verification successful",
-                    "SUCCESS"
+                    "",
+                    ""
                 )
             } else {
                 VerificationResult(
                     false,
-                    "Signature verification failed",
-                    "SIGNATURE_VERIFICATION_FAILED"
+                    "ERROR_MESSAGE_VERIFICATION_FAILED",
+                    "ERROR_CODE_VERIFICATION_FAILED"
                 )
             }
         } catch (e: Exception) {

--- a/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/PresentationVerifier.kt
+++ b/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/PresentationVerifier.kt
@@ -58,7 +58,7 @@ class PresentationVerifier {
 
     fun verifyV2(presentation: String): PresentationVerificationResultV2 {
 
-        val presentationVerificationResult: VerificationResult = getPresentationVerificationStatusV2(presentation)
+        val presentationVerificationResult: VerificationResult = getPresentationVerificationResult(presentation)
 
         val verifiableCredentials = JSONObject(presentation).getJSONArray(Shared.KEY_VERIFIABLE_CREDENTIAL)
         val vcVerificationResults: List<VCResultV2> = getVCVerificationResultsV2(verifiableCredentials)
@@ -97,7 +97,7 @@ class PresentationVerifier {
             }
         }
     }
-    private fun getPresentationVerificationStatusV2(presentation: String): VerificationResult {
+    private fun getPresentationVerificationResult(presentation: String): VerificationResult {
         logger.info("Received Presentation For Verification - Start")
         val vcJsonLdObject: JsonLDObject
 
@@ -267,12 +267,12 @@ class PresentationVerifier {
         presentation: String,
         statusPurposeList: List<String> = emptyList()
     ): PresentationResultWithCredentialStatusV2 {
-        val presentationVerificationStatus = getPresentationVerificationStatusV2(presentation)
+        val presentationVerificationResult = getPresentationVerificationResult(presentation)
 
         val verifiableCredentials = JSONObject(presentation).getJSONArray(Shared.KEY_VERIFIABLE_CREDENTIAL)
         val vcVerificationResults: List<VCResultWithCredentialStatusV2> = getVCVerificationResultsWithCredentialStatusV2(verifiableCredentials, statusPurposeList)
 
-        return PresentationResultWithCredentialStatusV2(presentationVerificationStatus, vcVerificationResults)
+        return PresentationResultWithCredentialStatusV2(presentationVerificationResult, vcVerificationResults)
     }
 }
 

--- a/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/PresentationVerifier.kt
+++ b/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/PresentationVerifier.kt
@@ -10,6 +10,8 @@ import io.ipfs.multibase.Multibase
 import io.mosip.vercred.vcverifier.constants.CredentialFormat
 import io.mosip.vercred.vcverifier.constants.CredentialVerifierConstants.ED25519_PROOF_TYPE_2018
 import io.mosip.vercred.vcverifier.constants.CredentialVerifierConstants.ED25519_PROOF_TYPE_2020
+import io.mosip.vercred.vcverifier.constants.CredentialVerifierConstants.ERROR_CODE_VERIFICATION_FAILED
+import io.mosip.vercred.vcverifier.constants.CredentialVerifierConstants.ERROR_MESSAGE_VERIFICATION_FAILED
 import io.mosip.vercred.vcverifier.constants.CredentialVerifierConstants.JSON_WEB_PROOF_TYPE_2020
 import io.mosip.vercred.vcverifier.constants.Shared
 import io.mosip.vercred.vcverifier.data.PresentationVerificationResult
@@ -116,8 +118,8 @@ class PresentationVerifier {
             } else {
                 VerificationResult(
                     false,
-                    "ERROR_MESSAGE_VERIFICATION_FAILED",
-                    "ERROR_CODE_VERIFICATION_FAILED"
+                    ERROR_MESSAGE_VERIFICATION_FAILED,
+                    ERROR_CODE_VERIFICATION_FAILED
                 )
             }
         } catch (e: Exception) {

--- a/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/credentialverifier/validator/SdJwtValidator.kt
+++ b/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/credentialverifier/validator/SdJwtValidator.kt
@@ -461,7 +461,7 @@ class SdJwtValidator {
         if (iat <= 0) {
             throw ValidationException(
                 "Missing or invalid 'iat' in Key Binding JWT",
-                "${ERROR_CODE_INVALID}_KB_JWT_IAT"
+                "${ERROR_CODE_INVALID}KB_JWT_IAT"
             )
         }
 

--- a/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/data/Data.kt
+++ b/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/data/Data.kt
@@ -63,3 +63,22 @@ data class CredentialVerificationSummary(
     val verificationResult: VerificationResult,
     val credentialStatus: Map<String, CredentialStatusResult>
 )
+
+data class PresentationVerificationResultV2(
+    var proofVerificationStatus: VerificationResult,
+    var vcResults: List<VCResultV2>
+)
+data class VCResultV2(
+    val vc: String,
+    val status: VerificationResult
+)
+
+data class PresentationResultWithCredentialStatusV2(
+    var proofVerificationStatus: VerificationResult,
+    var vcResults: List<VCResultWithCredentialStatusV2>
+)
+data class VCResultWithCredentialStatusV2(
+    val vc: String,
+    val status: VerificationResult,
+    val credentialStatus: Map<String, CredentialStatusResult>
+)

--- a/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/data/Data.kt
+++ b/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/data/Data.kt
@@ -65,20 +65,20 @@ data class CredentialVerificationSummary(
 )
 
 data class PresentationVerificationResultV2(
-    var proofVerificationStatus: VerificationResult,
+    var proofVerificationResult: VerificationResult,
     var vcResults: List<VCResultV2>
 )
 data class VCResultV2(
     val vc: String,
-    val status: VerificationResult
+    val verificationResult: VerificationResult
 )
 
 data class PresentationResultWithCredentialStatusV2(
-    var proofVerificationStatus: VerificationResult,
+    var proofVerificationResult: VerificationResult,
     var vcResults: List<VCResultWithCredentialStatusV2>
 )
 data class VCResultWithCredentialStatusV2(
     val vc: String,
-    val status: VerificationResult,
+    val verificationResult: VerificationResult,
     val credentialStatus: Map<String, CredentialStatusResult>
 )

--- a/vc-verifier/kotlin/vcverifier/src/test/java/io/mosip/vercred/vcverifier/PresentationVerifierTest.kt
+++ b/vc-verifier/kotlin/vcverifier/src/test/java/io/mosip/vercred/vcverifier/PresentationVerifierTest.kt
@@ -19,10 +19,12 @@ import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.Timeout
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.assertThrows
 import testutils.mockHttpResponse
 import testutils.readClasspathFile
 import java.util.concurrent.TimeUnit
+import io.mosip.vercred.vcverifier.data.PresentationResultWithCredentialStatusV2
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class PresentationVerifierTest {
@@ -151,5 +153,139 @@ class PresentationVerifierTest {
         assertEquals("revocation", credentialStatusEntry.key)
         assertNull(credentialStatusEntry.value.error)
         assertEquals(credentialStatusEntry.value.isValid, true)
+    }
+
+    @Test
+    @Timeout(20, unit = TimeUnit.SECONDS)
+    fun `V2 should return success for valid Ed25519Signature2018 VP`() {
+        val vp = readClasspathFile("vp/Ed25519Signature2018SignedVP-didKey.json")
+
+        val result = PresentationVerifier().verifyV2(vp)
+
+        assertTrue(result.proofVerificationStatus.verificationStatus)
+        assertEquals("SUCCESS", result.proofVerificationStatus.verificationErrorCode)
+    }
+
+    @Test
+    @Timeout(20, unit = TimeUnit.SECONDS)
+    fun `V2 should return success for valid JsonWebSignature2020 VP`() {
+        mockHttpResponse(
+            "https://api.released.mosip.net/identity-service/02b073b8-aacd-472e-b63f-265bb7ccdd9f/did.json",
+            readClasspathFile("vp/public_key/didIdentityServiceKey.json")
+        )
+
+        val vp = readClasspathFile("vp/JsonWebSignature2020SignedVP-didJws.json")
+
+        val result = PresentationVerifier().verifyV2(vp)
+
+        assertTrue(result.proofVerificationStatus.verificationStatus)
+        assertTrue(result.vcResults[0].status.verificationStatus)
+        assertNotNull(result.vcResults[0].vc)
+        assertNotEquals("", result.vcResults[0].vc)
+    }
+
+    @Test
+    @Timeout(20, unit = TimeUnit.SECONDS)
+    fun `V2 should return failure for invalid VP signature`() {
+        val vp = readClasspathFile("vp/InvalidEd25519Signature2018SignedVP-didKey.json")
+
+        val result = PresentationVerifier().verifyV2(vp)
+
+        assertFalse(result.proofVerificationStatus.verificationStatus)
+        assertEquals("SIGNATURE_VERIFICATION_FAILED", result.proofVerificationStatus.verificationErrorCode)
+    }
+
+    @Test
+    @Timeout(20, unit = TimeUnit.SECONDS)
+    fun `V2 should return unsupported DID error when public key not found`() {
+        val vp = readClasspathFile("vp/InvalidPublicKeyEd25519Signature2018SignedVP-didKey.json")
+
+        val result = PresentationVerifier().verifyV2(vp)
+
+        assertFalse(result.proofVerificationStatus.verificationStatus)
+        assertEquals("UNSUPPORTED_DID", result.proofVerificationStatus.verificationErrorCode)
+        assertNotNull(result.proofVerificationStatus.verificationMessage)
+    }
+
+
+    @Test
+    fun `V2 should throw error when VP is not JSON-LD`() {
+        assertThrows<PresentationNotSupportedException> {
+            PresentationVerifier().verifyV2("invalid")
+        }
+    }
+
+    @Test
+    @Timeout(20, unit = TimeUnit.SECONDS)
+    fun `V2 should return failure for invalid Ed25519Signature2020 VP`() {
+        val vp = readClasspathFile("vp/Ed25519Signature2020SignedVP-didKey.json")
+
+        val result = PresentationVerifier().verifyV2(vp)
+
+        assertFalse(result.proofVerificationStatus.verificationStatus)
+    }
+
+    @Test
+    @Timeout(20, unit = TimeUnit.SECONDS)
+    fun `V2 should verify VC and return revoked credential status`() {
+        val mockStatusListJson = readClasspathFile("ldp_vc/mosipRevokedStatusList.json")
+        val vp = readClasspathFile("vp/VPWithRevokedVC.json")
+
+        mockHttpResponse(
+            "https://mosip.github.io/inji-config/qa-inji1/mock/did.json",
+            readClasspathFile("vp/public_key/didMockKey.json")
+        )
+
+        val realUrl =
+            "https://injicertify-mock.qa-inji1.mosip.net/v1/certify/credentials/status-list/56622ad1-c304-4d7a-baf0-08836d63c2bf"
+        mockHttpResponse(realUrl, mockStatusListJson)
+
+        val result: PresentationResultWithCredentialStatusV2 =
+            PresentationVerifier().verifyAndGetCredentialStatusV2(
+                vp,
+                listOf("revocation")
+            )
+
+        assertFalse(result.proofVerificationStatus.verificationStatus)
+        assertTrue(result.vcResults[0].status.verificationStatus)
+
+        val credentialStatus = result.vcResults[0].credentialStatus
+        val entry = credentialStatus.entries.first()
+
+        assertEquals("revocation", entry.key)
+        assertFalse(entry.value.isValid)
+        assertNull(entry.value.error)
+    }
+
+    @Test
+    @Timeout(20, unit = TimeUnit.SECONDS)
+    fun `V2 should verify VC and return unrevoked credential status`() {
+        val mockStatusListJson = readClasspathFile("ldp_vc/mosipUnrevokedStatusList.json")
+        val vp = readClasspathFile("vp/VPWithUnrevokedVC.json")
+
+        mockHttpResponse(
+            "https://mosip.github.io/inji-config/qa-inji1/mock/did.json",
+            readClasspathFile("vp/public_key/didMockKey.json")
+        )
+
+        val realUrl =
+            "https://injicertify-mock.qa-inji1.mosip.net/v1/certify/credentials/status-list/56622ad1-c304-4d7a-baf0-08836d63c2bf"
+        mockHttpResponse(realUrl, mockStatusListJson)
+
+        val result: PresentationResultWithCredentialStatusV2 =
+            PresentationVerifier().verifyAndGetCredentialStatusV2(
+                vp,
+                listOf("revocation")
+            )
+
+        assertFalse(result.proofVerificationStatus.verificationStatus)
+        assertTrue(result.vcResults[0].status.verificationStatus)
+
+        val credentialStatus = result.vcResults[0].credentialStatus
+        val entry = credentialStatus.entries.first()
+
+        assertEquals("revocation", entry.key)
+        assertTrue(entry.value.isValid)
+        assertNull(entry.value.error)
     }
 }

--- a/vc-verifier/kotlin/vcverifier/src/test/java/io/mosip/vercred/vcverifier/PresentationVerifierTest.kt
+++ b/vc-verifier/kotlin/vcverifier/src/test/java/io/mosip/vercred/vcverifier/PresentationVerifierTest.kt
@@ -1,6 +1,7 @@
 package io.mosip.vercred.vcverifier
 
 import io.mockk.mockkObject
+import io.mosip.vercred.vcverifier.constants.CredentialVerifierConstants.ERROR_CODE_VERIFICATION_FAILED
 import io.mosip.vercred.vcverifier.data.PresentationResultWithCredentialStatus
 import io.mosip.vercred.vcverifier.data.VPVerificationStatus
 import io.mosip.vercred.vcverifier.data.VerificationStatus
@@ -163,7 +164,7 @@ class PresentationVerifierTest {
         val result = PresentationVerifier().verifyV2(vp)
 
         assertTrue(result.proofVerificationResult.verificationStatus)
-        assertEquals("SUCCESS", result.proofVerificationResult.verificationErrorCode)
+        assertEquals("", result.proofVerificationResult.verificationErrorCode)
     }
 
     @Test
@@ -192,7 +193,7 @@ class PresentationVerifierTest {
         val result = PresentationVerifier().verifyV2(vp)
 
         assertFalse(result.proofVerificationResult.verificationStatus)
-        assertEquals("SIGNATURE_VERIFICATION_FAILED", result.proofVerificationResult.verificationErrorCode)
+        assertEquals(ERROR_CODE_VERIFICATION_FAILED, result.proofVerificationResult.verificationErrorCode)
     }
 
     @Test

--- a/vc-verifier/kotlin/vcverifier/src/test/java/io/mosip/vercred/vcverifier/PresentationVerifierTest.kt
+++ b/vc-verifier/kotlin/vcverifier/src/test/java/io/mosip/vercred/vcverifier/PresentationVerifierTest.kt
@@ -200,7 +200,7 @@ class PresentationVerifierTest {
     fun `V2 should return unsupported DID error when public key not found`() {
         val vp = readClasspathFile("vp/InvalidPublicKeyEd25519Signature2018SignedVP-didKey.json")
 
-        assertThrows<UnsupportedDidUrl> { PresentationVerifier().verify(vp) }
+        assertThrows<UnsupportedDidUrl> { PresentationVerifier().verifyV2(vp) }
     }
 
 

--- a/vc-verifier/kotlin/vcverifier/src/test/java/io/mosip/vercred/vcverifier/PresentationVerifierTest.kt
+++ b/vc-verifier/kotlin/vcverifier/src/test/java/io/mosip/vercred/vcverifier/PresentationVerifierTest.kt
@@ -162,8 +162,8 @@ class PresentationVerifierTest {
 
         val result = PresentationVerifier().verifyV2(vp)
 
-        assertTrue(result.proofVerificationStatus.verificationStatus)
-        assertEquals("SUCCESS", result.proofVerificationStatus.verificationErrorCode)
+        assertTrue(result.proofVerificationResult.verificationStatus)
+        assertEquals("SUCCESS", result.proofVerificationResult.verificationErrorCode)
     }
 
     @Test
@@ -178,8 +178,8 @@ class PresentationVerifierTest {
 
         val result = PresentationVerifier().verifyV2(vp)
 
-        assertTrue(result.proofVerificationStatus.verificationStatus)
-        assertTrue(result.vcResults[0].status.verificationStatus)
+        assertTrue(result.proofVerificationResult.verificationStatus)
+        assertTrue(result.vcResults[0].verificationResult.verificationStatus)
         assertNotNull(result.vcResults[0].vc)
         assertNotEquals("", result.vcResults[0].vc)
     }
@@ -191,8 +191,8 @@ class PresentationVerifierTest {
 
         val result = PresentationVerifier().verifyV2(vp)
 
-        assertFalse(result.proofVerificationStatus.verificationStatus)
-        assertEquals("SIGNATURE_VERIFICATION_FAILED", result.proofVerificationStatus.verificationErrorCode)
+        assertFalse(result.proofVerificationResult.verificationStatus)
+        assertEquals("SIGNATURE_VERIFICATION_FAILED", result.proofVerificationResult.verificationErrorCode)
     }
 
     @Test
@@ -200,11 +200,7 @@ class PresentationVerifierTest {
     fun `V2 should return unsupported DID error when public key not found`() {
         val vp = readClasspathFile("vp/InvalidPublicKeyEd25519Signature2018SignedVP-didKey.json")
 
-        val result = PresentationVerifier().verifyV2(vp)
-
-        assertFalse(result.proofVerificationStatus.verificationStatus)
-        assertEquals("UNSUPPORTED_DID", result.proofVerificationStatus.verificationErrorCode)
-        assertNotNull(result.proofVerificationStatus.verificationMessage)
+        assertThrows<UnsupportedDidUrl> { PresentationVerifier().verify(vp) }
     }
 
 
@@ -222,7 +218,7 @@ class PresentationVerifierTest {
 
         val result = PresentationVerifier().verifyV2(vp)
 
-        assertFalse(result.proofVerificationStatus.verificationStatus)
+        assertFalse(result.proofVerificationResult.verificationStatus)
     }
 
     @Test
@@ -246,8 +242,8 @@ class PresentationVerifierTest {
                 listOf("revocation")
             )
 
-        assertFalse(result.proofVerificationStatus.verificationStatus)
-        assertTrue(result.vcResults[0].status.verificationStatus)
+        assertFalse(result.proofVerificationResult.verificationStatus)
+        assertTrue(result.vcResults[0].verificationResult.verificationStatus)
 
         val credentialStatus = result.vcResults[0].credentialStatus
         val entry = credentialStatus.entries.first()
@@ -278,8 +274,8 @@ class PresentationVerifierTest {
                 listOf("revocation")
             )
 
-        assertFalse(result.proofVerificationStatus.verificationStatus)
-        assertTrue(result.vcResults[0].status.verificationStatus)
+        assertFalse(result.proofVerificationResult.verificationStatus)
+        assertTrue(result.vcResults[0].verificationResult.verificationStatus)
 
         val credentialStatus = result.vcResults[0].credentialStatus
         val entry = credentialStatus.entries.first()


### PR DESCRIPTION
…wing error handling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added V2 presentation verification APIs and new V2 result types for verification and credential-status reporting; V1 flow preserved.

* **Bug Fixes**
  * Fixed formatting of an error-code string.

* **Tests**
  * Added comprehensive V2 tests covering successful verifications, failure modes, and credential-status (revoked/unrevoked) scenarios.

* **Chores**
  * Bumped library version for the next release.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->