### PR TITLE
[INJIVER-1523] use initCause() to attach the original exception

### DIFF
--- a/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/keyResolver/types/jwks/JwksPublicKeyResolver.kt
+++ b/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/keyResolver/types/jwks/JwksPublicKeyResolver.kt
@@ -31,7 +31,7 @@ class JwksPublicKeyResolver : PublicKeyResolver {
             return getPublicKeyFromJWK(jwk, kty)
         } catch (e: Exception) {
             throw if (e is PublicKeyNotFoundException) e
-                             else PublicKeyNotFoundException("Failed to resolve JWKS public key: ${e.message}")
+            else PublicKeyNotFoundException("Failed to resolve JWKS public key: ${e.message}").apply { initCause(e) }
         }
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error diagnostics for key resolution failures with enhanced exception chaining and contextual error messages. When unexpected issues occur during resolution, error context now provides clearer information and better diagnostic details, enabling developers to more effectively troubleshoot, identify root causes, and resolve verification failures quickly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->