### PR TITLE
fix(JwtValidator): replace java.util.Base64 with internal Base64Decoder to resolve Lint API level error

### DIFF
--- a/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/credentialverifier/validator/JwtValidator.kt
+++ b/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/credentialverifier/validator/JwtValidator.kt
@@ -17,7 +17,7 @@ class JwtValidator {
         try {
             val parts = trimmedCredential.split(".")
             if (parts.isNotEmpty()) {
-                val headerJson = String(Base64Decoder().decodeFromBase64(parts[0]))
+                val headerJson = String(Base64Decoder().decodeFromBase64Url(parts[0]))
                 if (headerJson.contains("\"alg\":\"none\"", ignoreCase = true)) {
                     return ValidationStatus("JWT algorithm 'none' is not allowed", "INVALID_ALGORITHM")
                 }

--- a/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/credentialverifier/validator/JwtValidator.kt
+++ b/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/credentialverifier/validator/JwtValidator.kt
@@ -3,7 +3,7 @@ package io.mosip.vercred.vcverifier.credentialverifier.validator
 import com.nimbusds.jwt.SignedJWT
 import io.mosip.vercred.vcverifier.data.ValidationStatus
 import java.util.Date
-import java.util.Base64
+import io.mosip.vercred.vcverifier.utils.Base64Decoder
 
 class JwtValidator {
     companion object {
@@ -17,7 +17,7 @@ class JwtValidator {
         try {
             val parts = trimmedCredential.split(".")
             if (parts.isNotEmpty()) {
-                val headerJson = String(Base64.getUrlDecoder().decode(parts[0]))
+                val headerJson = String(Base64Decoder().decodeFromBase64(parts[0]))
                 if (headerJson.contains("\"alg\":\"none\"", ignoreCase = true)) {
                     return ValidationStatus("JWT algorithm 'none' is not allowed", "INVALID_ALGORITHM")
                 }


### PR DESCRIPTION
### Background
In the previous VC Verifier PR, `java.util.Base64` was used to decode the JWT header in `JwtValidator.kt`. While this passed local unit tests, it caused the CI pipeline's `:vcverifier:lintDebug` task to fail. 

Android Lint flagged a `NewApi` violation because `java.util.Base64` requires API Level 26+, but this project supports a `minSdkVersion` of 23. 

### Changes Made
* Replaced `java.util.Base64` with the project's existing internal utility: `io.mosip.vercred.vcverifier.utils.Base64Decoder`.
* This ensures 100% backward compatibility for Android devices below API 26.

### Testing
* **Linting:** Bypasses the API 26 Lint error since it uses our custom decoder.
* **Unit Tests:** Local JVM tests (`.\gradlew test`) pass successfully (unlike `android.util.Base64`, which throws mock exceptions on local JVM environments).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Replaced the internal Base64 URL decoding used for JWT headers with a custom decoder utility; behavior and error handling for invalid or missing algorithms remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->