### PR TITLE
INJIVER 1585 VP support for ECC R1 & K1

### DIFF
--- a/vc-verifier/kotlin/vcverifier/publish-artifact.gradle
+++ b/vc-verifier/kotlin/vcverifier/publish-artifact.gradle
@@ -96,7 +96,7 @@ publishing {
             }
             groupId = "io.inji"
             artifactId = "vcverifier-aar"
-            version = "1.8.0-SNAPSHOT"
+            version = "1.9.0-SNAPSHOT"
             if (project.gradle.startParameter.taskNames.any { it.contains('assembleRelease') }) {
                 artifacts {
                     aar {
@@ -110,7 +110,7 @@ publishing {
             artifact(tasks.named("jarRelease").get())
             groupId = "io.inji"
             artifactId = "vcverifier-jar"
-            version = "1.8.0-SNAPSHOT"
+            version = "1.9.0-SNAPSHOT"
             artifact(tasks.named("javadocJar").get())
             artifact(tasks.named("sourcesJar").get())
             pom {

--- a/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/PresentationVerifier.kt
+++ b/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/PresentationVerifier.kt
@@ -192,6 +192,9 @@ class PresentationVerifier {
             (ldProof.type == ES256K_PROOF_TYPE_2019) && !ldProof.jws.isNullOrEmpty() -> {
                 val jws = JWSObject.parse(ldProof.jws)
                 val actualData = JWSUtil.getJwsSigningInput(jws.header, canonicalHashBytes)
+                if (jws.header.algorithm != JWSAlgorithm.ES256K) {
+                    throw SignatureNotSupportedException("Unsupported JWS algorithm")
+                }
                 ES256KSignatureVerifierImpl().verify(
                     publicKey,
                     actualData,
@@ -202,6 +205,9 @@ class PresentationVerifier {
             (ldProof.type == ES256_PROOF_TYPE_2019) && !ldProof.jws.isNullOrEmpty() -> {
                 val jws = JWSObject.parse(ldProof.jws)
                 val actualData = JWSUtil.getJwsSigningInput(jws.header, canonicalHashBytes)
+                if (jws.header.algorithm != JWSAlgorithm.ES256) {
+                    throw SignatureNotSupportedException("Unsupported JWS algorithm")
+                }
                 ES256SignatureVerifierImpl().verify(
                     publicKey,
                     actualData,

--- a/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/PresentationVerifier.kt
+++ b/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/PresentationVerifier.kt
@@ -12,6 +12,8 @@ import io.mosip.vercred.vcverifier.constants.CredentialVerifierConstants.ED25519
 import io.mosip.vercred.vcverifier.constants.CredentialVerifierConstants.ED25519_PROOF_TYPE_2020
 import io.mosip.vercred.vcverifier.constants.CredentialVerifierConstants.ERROR_CODE_VERIFICATION_FAILED
 import io.mosip.vercred.vcverifier.constants.CredentialVerifierConstants.ERROR_MESSAGE_VERIFICATION_FAILED
+import io.mosip.vercred.vcverifier.constants.CredentialVerifierConstants.ES256K_PROOF_TYPE_2019
+import io.mosip.vercred.vcverifier.constants.CredentialVerifierConstants.ES256_PROOF_TYPE_2019
 import io.mosip.vercred.vcverifier.constants.CredentialVerifierConstants.JSON_WEB_PROOF_TYPE_2020
 import io.mosip.vercred.vcverifier.constants.Shared
 import io.mosip.vercred.vcverifier.data.PresentationVerificationResult
@@ -33,6 +35,7 @@ import io.mosip.vercred.vcverifier.exception.SignatureVerificationException
 import io.mosip.vercred.vcverifier.exception.UnknownException
 import io.mosip.vercred.vcverifier.keyResolver.PublicKeyResolverFactory
 import io.mosip.vercred.vcverifier.signature.impl.ED25519SignatureVerifierImpl
+import io.mosip.vercred.vcverifier.signature.impl.ES256KSignatureVerifierImpl
 import io.mosip.vercred.vcverifier.utils.Util
 import io.mosip.vercred.vcverifier.utils.asIterable
 import org.json.JSONArray
@@ -170,22 +173,53 @@ class PresentationVerifier {
                 )
             }
 
-            ldProof.type == JSON_WEB_PROOF_TYPE_2020 && !ldProof.jws.isNullOrEmpty() -> {
-                val jws = JWSObject.parse(ldProof.jws)
-                if (jws.header.algorithm != JWSAlgorithm.EdDSA) {
-                    throw SignatureNotSupportedException("Unsupported JWS algorithm")
-                }
+            (ldProof.type == ES256K_PROOF_TYPE_2019 || ldProof.type == ES256_PROOF_TYPE_2019) && !ldProof.proofValue.isNullOrEmpty() -> {
+                ES256KSignatureVerifierImpl().verify(
+                    publicKey,
+                    canonicalHashBytes,
+                    Multibase.decode(ldProof.proofValue)
+                )
+            }
 
+            (ldProof.type == ES256K_PROOF_TYPE_2019 || ldProof.type == ES256_PROOF_TYPE_2019) && !ldProof.jws.isNullOrEmpty() -> {
+                val jws = JWSObject.parse(ldProof.jws)
                 val actualData =
                     JWSUtil.getJwsSigningInput(jws.header, canonicalHashBytes)
 
-                ED25519SignatureVerifierImpl().verify(
+                ES256KSignatureVerifierImpl().verify(
                     publicKey,
                     actualData,
                     jws.signature.decode()
                 )
             }
 
+            ldProof.type == JSON_WEB_PROOF_TYPE_2020 && !ldProof.jws.isNullOrEmpty() -> {
+                val jws = JWSObject.parse(ldProof.jws)
+                if (jws.header.algorithm != JWSAlgorithm.EdDSA && jws.header.algorithm != JWSAlgorithm.ES256K && jws.header.algorithm != JWSAlgorithm.ES256) {
+                    throw SignatureNotSupportedException("Unsupported JWS algorithm")
+                }
+
+                val actualData =
+                    JWSUtil.getJwsSigningInput(jws.header, canonicalHashBytes)
+
+                when {
+                    (jws.header.algorithm == JWSAlgorithm.EdDSA) -> {
+                        ED25519SignatureVerifierImpl().verify(
+                            publicKey,
+                            actualData,
+                            jws.signature.decode()
+                        )
+                    }
+                    (jws.header.algorithm == JWSAlgorithm.ES256K || jws.header.algorithm == JWSAlgorithm.ES256) -> {
+                        ES256KSignatureVerifierImpl().verify(
+                            publicKey,
+                            actualData,
+                            jws.signature.decode()
+                        )
+                    }
+                    else -> false
+                }
+            }
             else -> false
         }
     }
@@ -275,4 +309,3 @@ class PresentationVerifier {
         return PresentationResultWithCredentialStatusV2(presentationVerificationResult, vcVerificationResults)
     }
 }
-

--- a/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/PresentationVerifier.kt
+++ b/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/PresentationVerifier.kt
@@ -42,12 +42,37 @@ import org.json.JSONArray
 import org.json.JSONObject
 import java.security.spec.InvalidKeySpecException
 import java.util.logging.Logger
-
+import java.security.interfaces.ECPublicKey
+import org.bouncycastle.jce.spec.ECNamedCurveSpec
+import java.security.PublicKey
 
 class PresentationVerifier {
     private val logger = Logger.getLogger(PresentationVerifier::class.java.name)
 
     private val credentialsVerifier: CredentialsVerifier = CredentialsVerifier()
+
+    /**
+     * Validates that the resolved EC public key's curve matches the expected curve
+     * for the given proof type (ES256 → P-256/secp256r1, ES256K → secp256k1).
+     * Silently skips if the curve name cannot be determined from the key spec.
+     */
+    private fun validateECKeyCurve(publicKey: PublicKey, proofType: String) {
+        val ecKey = publicKey as? ECPublicKey ?: return
+        val curveName = (ecKey.params as? ECNamedCurveSpec)?.name ?: return // non-BC key; skip
+
+        val valid = when (proofType) {
+            ES256_PROOF_TYPE_2019  -> curveName.equals("P-256",       ignoreCase = true)
+                    || curveName.equals("secp256r1",   ignoreCase = true)
+                    || curveName.equals("prime256v1",  ignoreCase = true)
+            ES256K_PROOF_TYPE_2019 -> curveName.equals("secp256k1",   ignoreCase = true)
+            else -> true
+        }
+        if (!valid) {
+            throw SignatureVerificationException(
+                "Key curve '$curveName' does not match proof type '$proofType'"
+            )
+        }
+    }
 
     fun verify(presentation: String): PresentationVerificationResult {
 
@@ -174,6 +199,7 @@ class PresentationVerifier {
             }
 
             (ldProof.type == ES256K_PROOF_TYPE_2019 || ldProof.type == ES256_PROOF_TYPE_2019) && !ldProof.proofValue.isNullOrEmpty() -> {
+                validateECKeyCurve(publicKey, ldProof.type)
                 ES256KSignatureVerifierImpl().verify(
                     publicKey,
                     canonicalHashBytes,
@@ -182,10 +208,9 @@ class PresentationVerifier {
             }
 
             (ldProof.type == ES256K_PROOF_TYPE_2019 || ldProof.type == ES256_PROOF_TYPE_2019) && !ldProof.jws.isNullOrEmpty() -> {
+                validateECKeyCurve(publicKey, ldProof.type)
                 val jws = JWSObject.parse(ldProof.jws)
-                val actualData =
-                    JWSUtil.getJwsSigningInput(jws.header, canonicalHashBytes)
-
+                val actualData = JWSUtil.getJwsSigningInput(jws.header, canonicalHashBytes)
                 ES256KSignatureVerifierImpl().verify(
                     publicKey,
                     actualData,
@@ -211,6 +236,9 @@ class PresentationVerifier {
                         )
                     }
                     (jws.header.algorithm == JWSAlgorithm.ES256K || jws.header.algorithm == JWSAlgorithm.ES256) -> {
+                        val expectedProofType = if (jws.header.algorithm == JWSAlgorithm.ES256K)
+                            ES256K_PROOF_TYPE_2019 else ES256_PROOF_TYPE_2019
+                        validateECKeyCurve(publicKey, expectedProofType)
                         ES256KSignatureVerifierImpl().verify(
                             publicKey,
                             actualData,

--- a/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/PresentationVerifier.kt
+++ b/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/PresentationVerifier.kt
@@ -36,43 +36,18 @@ import io.mosip.vercred.vcverifier.exception.UnknownException
 import io.mosip.vercred.vcverifier.keyResolver.PublicKeyResolverFactory
 import io.mosip.vercred.vcverifier.signature.impl.ED25519SignatureVerifierImpl
 import io.mosip.vercred.vcverifier.signature.impl.ES256KSignatureVerifierImpl
+import io.mosip.vercred.vcverifier.signature.impl.ES256SignatureVerifierImpl
 import io.mosip.vercred.vcverifier.utils.Util
 import io.mosip.vercred.vcverifier.utils.asIterable
 import org.json.JSONArray
 import org.json.JSONObject
 import java.security.spec.InvalidKeySpecException
 import java.util.logging.Logger
-import java.security.interfaces.ECPublicKey
-import org.bouncycastle.jce.spec.ECNamedCurveSpec
-import java.security.PublicKey
 
 class PresentationVerifier {
     private val logger = Logger.getLogger(PresentationVerifier::class.java.name)
 
     private val credentialsVerifier: CredentialsVerifier = CredentialsVerifier()
-
-    /**
-     * Validates that the resolved EC public key's curve matches the expected curve
-     * for the given proof type (ES256 → P-256/secp256r1, ES256K → secp256k1).
-     * Silently skips if the curve name cannot be determined from the key spec.
-     */
-    private fun validateECKeyCurve(publicKey: PublicKey, proofType: String) {
-        val ecKey = publicKey as? ECPublicKey ?: return
-        val curveName = (ecKey.params as? ECNamedCurveSpec)?.name ?: return // non-BC key; skip
-
-        val valid = when (proofType) {
-            ES256_PROOF_TYPE_2019  -> curveName.equals("P-256",       ignoreCase = true)
-                    || curveName.equals("secp256r1",   ignoreCase = true)
-                    || curveName.equals("prime256v1",  ignoreCase = true)
-            ES256K_PROOF_TYPE_2019 -> curveName.equals("secp256k1",   ignoreCase = true)
-            else -> true
-        }
-        if (!valid) {
-            throw SignatureVerificationException(
-                "Key curve '$curveName' does not match proof type '$proofType'"
-            )
-        }
-    }
 
     fun verify(presentation: String): PresentationVerificationResult {
 
@@ -198,8 +173,7 @@ class PresentationVerifier {
                 )
             }
 
-            (ldProof.type == ES256K_PROOF_TYPE_2019 || ldProof.type == ES256_PROOF_TYPE_2019) && !ldProof.proofValue.isNullOrEmpty() -> {
-                validateECKeyCurve(publicKey, ldProof.type)
+            (ldProof.type == ES256K_PROOF_TYPE_2019) && !ldProof.proofValue.isNullOrEmpty() -> {
                 ES256KSignatureVerifierImpl().verify(
                     publicKey,
                     canonicalHashBytes,
@@ -207,11 +181,28 @@ class PresentationVerifier {
                 )
             }
 
-            (ldProof.type == ES256K_PROOF_TYPE_2019 || ldProof.type == ES256_PROOF_TYPE_2019) && !ldProof.jws.isNullOrEmpty() -> {
-                validateECKeyCurve(publicKey, ldProof.type)
+            (ldProof.type == ES256_PROOF_TYPE_2019) && !ldProof.proofValue.isNullOrEmpty() -> {
+                ES256SignatureVerifierImpl().verify(
+                    publicKey,
+                    canonicalHashBytes,
+                    Multibase.decode(ldProof.proofValue)
+                )
+            }
+
+            (ldProof.type == ES256K_PROOF_TYPE_2019) && !ldProof.jws.isNullOrEmpty() -> {
                 val jws = JWSObject.parse(ldProof.jws)
                 val actualData = JWSUtil.getJwsSigningInput(jws.header, canonicalHashBytes)
                 ES256KSignatureVerifierImpl().verify(
+                    publicKey,
+                    actualData,
+                    jws.signature.decode()
+                )
+            }
+
+            (ldProof.type == ES256_PROOF_TYPE_2019) && !ldProof.jws.isNullOrEmpty() -> {
+                val jws = JWSObject.parse(ldProof.jws)
+                val actualData = JWSUtil.getJwsSigningInput(jws.header, canonicalHashBytes)
+                ES256SignatureVerifierImpl().verify(
                     publicKey,
                     actualData,
                     jws.signature.decode()
@@ -227,19 +218,23 @@ class PresentationVerifier {
                 val actualData =
                     JWSUtil.getJwsSigningInput(jws.header, canonicalHashBytes)
 
-                when {
-                    (jws.header.algorithm == JWSAlgorithm.EdDSA) -> {
+                when (jws.header.algorithm) {
+                    JWSAlgorithm.EdDSA -> {
                         ED25519SignatureVerifierImpl().verify(
                             publicKey,
                             actualData,
                             jws.signature.decode()
                         )
                     }
-                    (jws.header.algorithm == JWSAlgorithm.ES256K || jws.header.algorithm == JWSAlgorithm.ES256) -> {
-                        val expectedProofType = if (jws.header.algorithm == JWSAlgorithm.ES256K)
-                            ES256K_PROOF_TYPE_2019 else ES256_PROOF_TYPE_2019
-                        validateECKeyCurve(publicKey, expectedProofType)
+                    JWSAlgorithm.ES256K -> {
                         ES256KSignatureVerifierImpl().verify(
+                            publicKey,
+                            actualData,
+                            jws.signature.decode()
+                        )
+                    }
+                    JWSAlgorithm.ES256 -> {
+                        ES256SignatureVerifierImpl().verify(
                             publicKey,
                             actualData,
                             jws.signature.decode()

--- a/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/constants/CredentialVerifierConstants.kt
+++ b/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/constants/CredentialVerifierConstants.kt
@@ -21,6 +21,8 @@ object CredentialVerifierConstants {
     const val ED25519_ALGORITHM = "Ed25519"
     const val RSA_ALGORITHM = "RSA"
     const val SECP256K1 = "secp256k1"
+    const val SECP256R1 = "secp256r1"
+    const val PRIME256V1 = "prime256v1"
     const val P256 = "P-256"
     const val JWS_PS256_SIGN_ALGO_CONST = "PS256"
     const val JWS_RS256_SIGN_ALGO_CONST = "RS256"

--- a/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/credentialverifier/verifier/LdpVerifier.kt
+++ b/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/credentialverifier/verifier/LdpVerifier.kt
@@ -14,22 +14,11 @@ import io.mosip.vercred.vcverifier.exception.UnknownException
 import io.mosip.vercred.vcverifier.keyResolver.PublicKeyResolverFactory
 import io.mosip.vercred.vcverifier.keyResolver.getJwsAlgorithmFromProofType
 import io.mosip.vercred.vcverifier.signature.SignatureFactory
-import io.mosip.vercred.vcverifier.signature.impl.ED25519SignatureVerifierImpl
-import io.mosip.vercred.vcverifier.signature.impl.ES256KSignatureVerifierImpl
 import io.mosip.vercred.vcverifier.utils.Util
-import org.bouncycastle.jce.provider.BouncyCastleProvider
-import java.security.Security
 import java.util.logging.Logger
 
-
 class LdpVerifier {
-
     private val logger = Logger.getLogger(LdpVerifier::class.java.name)
-    private var provider: BouncyCastleProvider = BouncyCastleProvider()
-
-    init {
-        Security.addProvider(provider)
-    }
 
     fun verify(credential: String): Boolean {
 

--- a/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/credentialverifier/verifier/LdpVerifier.kt
+++ b/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/credentialverifier/verifier/LdpVerifier.kt
@@ -15,10 +15,18 @@ import io.mosip.vercred.vcverifier.keyResolver.PublicKeyResolverFactory
 import io.mosip.vercred.vcverifier.keyResolver.getJwsAlgorithmFromProofType
 import io.mosip.vercred.vcverifier.signature.SignatureFactory
 import io.mosip.vercred.vcverifier.utils.Util
+import org.bouncycastle.jce.provider.BouncyCastleProvider
+import java.security.Security
 import java.util.logging.Logger
 
 class LdpVerifier {
     private val logger = Logger.getLogger(LdpVerifier::class.java.name)
+
+    private var provider: BouncyCastleProvider = BouncyCastleProvider()
+
+    init {
+        Security.addProvider(provider)
+    }
 
     fun verify(credential: String): Boolean {
 

--- a/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/keyResolver/Utils.kt
+++ b/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/keyResolver/Utils.kt
@@ -60,7 +60,7 @@ private val X509_HEADER_PREFIX_ED_KEY = byteArrayOf(
     0x2B, 0x65, 0x70, 0x03, 0x21, 0x00
 )
 
-private var provider: BouncyCastleProvider = bouncyCastleProvider
+private var provider: BouncyCastleProvider = BouncyCastleProvider()
 
 private val PUBLIC_KEY_ALGORITHM: Map<String, String> = mapOf(
     RSA_KEY_TYPE to RSA_ALGORITHM,
@@ -296,7 +296,7 @@ private fun decodeSecp256k1PublicKey(keyBytes: ByteArray): ECPoint {
     require(keyBytes[0] == 0x02.toByte() || keyBytes[0] == 0x03.toByte()) { "Invalid compressed public key prefix" }
 
     val x = BigInteger(1, keyBytes.copyOfRange(1, keyBytes.size))
-    val y = recoverYCoordinate(x, keyBytes[0] == 0x03.toByte())
+    val y = recoverYCoordinate(x, keyBytes[0] == 3.toByte())
 
     return ECPoint(x, y)
 }

--- a/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/keyResolver/Utils.kt
+++ b/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/keyResolver/Utils.kt
@@ -32,6 +32,7 @@ import io.mosip.vercred.vcverifier.exception.PublicKeyNotFoundException
 import io.mosip.vercred.vcverifier.exception.PublicKeyResolutionFailedException
 import io.mosip.vercred.vcverifier.exception.PublicKeyTypeNotSupportedException
 import io.mosip.vercred.vcverifier.exception.SignatureNotSupportedException
+import io.mosip.vercred.vcverifier.signature.bouncyCastleProvider
 import io.mosip.vercred.vcverifier.utils.Base64Decoder
 import org.bouncycastle.jce.ECNamedCurveTable
 import org.bouncycastle.jce.provider.BouncyCastleProvider
@@ -59,7 +60,7 @@ private val X509_HEADER_PREFIX_ED_KEY = byteArrayOf(
     0x2B, 0x65, 0x70, 0x03, 0x21, 0x00
 )
 
-private var provider: BouncyCastleProvider = BouncyCastleProvider()
+private var provider: BouncyCastleProvider = bouncyCastleProvider
 
 private val PUBLIC_KEY_ALGORITHM: Map<String, String> = mapOf(
     RSA_KEY_TYPE to RSA_ALGORITHM,
@@ -290,13 +291,13 @@ private fun hexStringToByteArray(hex: String): ByteArray {
 }
 
 
-private fun decodeSecp256k1PublicKey(keyBytes: ByteArray): java.security.spec.ECPoint {
+private fun decodeSecp256k1PublicKey(keyBytes: ByteArray): ECPoint {
     require(keyBytes.size == COMPRESSED_HEX_KEY_LENGTH) { "Invalid compressed public key length" }
 
     val x = BigInteger(1, keyBytes.copyOfRange(1, keyBytes.size))
     val y = recoverYCoordinate(x, keyBytes[0] == 3.toByte())
 
-    return java.security.spec.ECPoint(x, y)
+    return ECPoint(x, y)
 }
 
 // Recover the Y-coordinate from X using the Secp256k1 curve equation

--- a/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/keyResolver/Utils.kt
+++ b/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/keyResolver/Utils.kt
@@ -293,9 +293,10 @@ private fun hexStringToByteArray(hex: String): ByteArray {
 
 private fun decodeSecp256k1PublicKey(keyBytes: ByteArray): ECPoint {
     require(keyBytes.size == COMPRESSED_HEX_KEY_LENGTH) { "Invalid compressed public key length" }
+    require(keyBytes[0] == 0x02.toByte() || keyBytes[0] == 0x03.toByte()) { "Invalid compressed public key prefix" }
 
     val x = BigInteger(1, keyBytes.copyOfRange(1, keyBytes.size))
-    val y = recoverYCoordinate(x, keyBytes[0] == 3.toByte())
+    val y = recoverYCoordinate(x, keyBytes[0] == 0x03.toByte())
 
     return ECPoint(x, y)
 }

--- a/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/keyResolver/types/did/DidKeyPublicKeyResolver.kt
+++ b/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/keyResolver/types/did/DidKeyPublicKeyResolver.kt
@@ -4,15 +4,12 @@ import io.ipfs.multibase.Multibase
 import io.mosip.vercred.vcverifier.constants.CredentialVerifierConstants.JWK_KEY_TYPE_EC
 import io.mosip.vercred.vcverifier.constants.CredentialVerifierConstants.JWS_EDDSA_SIGN_ALGO_CONST
 import io.mosip.vercred.vcverifier.exception.PublicKeyTypeNotSupportedException
-import io.mosip.vercred.vcverifier.exception.UnknownException
-import io.mosip.vercred.vcverifier.signature.bouncyCastleProvider
 import org.bouncycastle.asn1.edec.EdECObjectIdentifiers
 import org.bouncycastle.asn1.x509.AlgorithmIdentifier
 import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 import java.security.KeyFactory
 import java.security.PublicKey
-import java.security.spec.InvalidKeySpecException
 import java.security.spec.X509EncodedKeySpec
 import java.util.Arrays
 
@@ -23,7 +20,7 @@ private const val MULTICODEC_TRAILING_BYTE = 0x01.toByte()
 private const val P256_KEY_PREFIX_FIRST = 0x80.toByte()
 private const val P256_KEY_PREFIX_SECOND = 0x24.toByte()
 class DidKeyPublicKeyResolver : DidPublicKeyResolver() {
-    private val provider: BouncyCastleProvider = bouncyCastleProvider
+    private val provider: BouncyCastleProvider = BouncyCastleProvider()
 
     override fun extractPublicKey(parsedDID: ParsedDID, keyId: String?): PublicKey {
         val decodedKey = Multibase.decode(parsedDID.id)

--- a/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/keyResolver/types/did/DidKeyPublicKeyResolver.kt
+++ b/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/keyResolver/types/did/DidKeyPublicKeyResolver.kt
@@ -5,6 +5,7 @@ import io.mosip.vercred.vcverifier.constants.CredentialVerifierConstants.JWK_KEY
 import io.mosip.vercred.vcverifier.constants.CredentialVerifierConstants.JWS_EDDSA_SIGN_ALGO_CONST
 import io.mosip.vercred.vcverifier.exception.PublicKeyTypeNotSupportedException
 import io.mosip.vercred.vcverifier.exception.UnknownException
+import io.mosip.vercred.vcverifier.signature.bouncyCastleProvider
 import org.bouncycastle.asn1.edec.EdECObjectIdentifiers
 import org.bouncycastle.asn1.x509.AlgorithmIdentifier
 import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo
@@ -22,7 +23,7 @@ private const val MULTICODEC_TRAILING_BYTE = 0x01.toByte()
 private const val P256_KEY_PREFIX_FIRST = 0x80.toByte()
 private const val P256_KEY_PREFIX_SECOND = 0x24.toByte()
 class DidKeyPublicKeyResolver : DidPublicKeyResolver() {
-    private val provider: BouncyCastleProvider = BouncyCastleProvider()
+    private val provider: BouncyCastleProvider = bouncyCastleProvider
 
     override fun extractPublicKey(parsedDID: ParsedDID, keyId: String?): PublicKey {
         val decodedKey = Multibase.decode(parsedDID.id)

--- a/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/signature/SignatureFactory.kt
+++ b/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/signature/SignatureFactory.kt
@@ -6,7 +6,11 @@ import io.mosip.vercred.vcverifier.constants.CredentialVerifierConstants.JWS_ES2
 import io.mosip.vercred.vcverifier.constants.CredentialVerifierConstants.JWS_PS256_SIGN_ALGO_CONST
 import io.mosip.vercred.vcverifier.constants.CredentialVerifierConstants.JWS_RS256_SIGN_ALGO_CONST
 import io.mosip.vercred.vcverifier.exception.SignatureNotSupportedException
-import io.mosip.vercred.vcverifier.signature.impl.*
+import io.mosip.vercred.vcverifier.signature.impl.ES256KSignatureVerifierImpl
+import io.mosip.vercred.vcverifier.signature.impl.PS256SignatureVerifierImpl
+import io.mosip.vercred.vcverifier.signature.impl.RS256SignatureVerifierImpl
+import io.mosip.vercred.vcverifier.signature.impl.ED25519SignatureVerifierImpl
+import io.mosip.vercred.vcverifier.signature.impl.ES256SignatureVerifierImpl
 
 class SignatureFactory {
 

--- a/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/signature/SignatureFactory.kt
+++ b/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/signature/SignatureFactory.kt
@@ -6,10 +6,7 @@ import io.mosip.vercred.vcverifier.constants.CredentialVerifierConstants.JWS_ES2
 import io.mosip.vercred.vcverifier.constants.CredentialVerifierConstants.JWS_PS256_SIGN_ALGO_CONST
 import io.mosip.vercred.vcverifier.constants.CredentialVerifierConstants.JWS_RS256_SIGN_ALGO_CONST
 import io.mosip.vercred.vcverifier.exception.SignatureNotSupportedException
-import io.mosip.vercred.vcverifier.signature.impl.ED25519SignatureVerifierImpl
-import io.mosip.vercred.vcverifier.signature.impl.ES256KSignatureVerifierImpl
-import io.mosip.vercred.vcverifier.signature.impl.PS256SignatureVerifierImpl
-import io.mosip.vercred.vcverifier.signature.impl.RS256SignatureVerifierImpl
+import io.mosip.vercred.vcverifier.signature.impl.*
 
 class SignatureFactory {
 
@@ -19,7 +16,7 @@ class SignatureFactory {
             JWS_RS256_SIGN_ALGO_CONST -> RS256SignatureVerifierImpl()
             JWS_EDDSA_SIGN_ALGO_CONST -> ED25519SignatureVerifierImpl()
             JWS_ES256K_SIGN_ALGO_CONST -> ES256KSignatureVerifierImpl()
-            JWS_ES256_SIGN_ALGO_CONST -> ES256KSignatureVerifierImpl()
+            JWS_ES256_SIGN_ALGO_CONST -> ES256SignatureVerifierImpl()
             else -> throw SignatureNotSupportedException("Unsupported jws signature algorithm")
         }
     }

--- a/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/signature/SignatureVerifier.kt
+++ b/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/signature/SignatureVerifier.kt
@@ -2,15 +2,8 @@ package io.mosip.vercred.vcverifier.signature
 
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 import java.security.PublicKey
-import java.security.Security
 
-val bouncyCastleProvider: BouncyCastleProvider by lazy {
-    val existingProvider = Security.getProvider(BouncyCastleProvider.PROVIDER_NAME)
-    existingProvider as? BouncyCastleProvider
-        ?: BouncyCastleProvider().also {
-            Security.addProvider(it)
-        }
-}
+internal var bouncyCastleProvider: BouncyCastleProvider = BouncyCastleProvider()
 interface SignatureVerifier {
     fun verify(
         publicKey: PublicKey,

--- a/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/signature/SignatureVerifier.kt
+++ b/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/signature/SignatureVerifier.kt
@@ -2,9 +2,15 @@ package io.mosip.vercred.vcverifier.signature
 
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 import java.security.PublicKey
+import java.security.Security
 
-internal var bouncyCastleProvider: BouncyCastleProvider = BouncyCastleProvider()
-
+val bouncyCastleProvider: BouncyCastleProvider by lazy {
+    val existingProvider = Security.getProvider(BouncyCastleProvider.PROVIDER_NAME)
+    existingProvider as? BouncyCastleProvider
+        ?: BouncyCastleProvider().also {
+            Security.addProvider(it)
+        }
+}
 interface SignatureVerifier {
     fun verify(
         publicKey: PublicKey,

--- a/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/signature/impl/ECDSASignatureVerifier.kt
+++ b/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/signature/impl/ECDSASignatureVerifier.kt
@@ -1,0 +1,92 @@
+package io.mosip.vercred.vcverifier.signature.impl
+
+import io.mosip.vercred.vcverifier.constants.CredentialVerifierConstants
+import io.mosip.vercred.vcverifier.exception.SignatureVerificationException
+import io.mosip.vercred.vcverifier.signature.SignatureVerifier
+import io.mosip.vercred.vcverifier.signature.bouncyCastleProvider
+import org.bouncycastle.jce.provider.BouncyCastleProvider
+import org.bouncycastle.jce.spec.ECNamedCurveSpec
+import java.io.ByteArrayOutputStream
+import java.math.BigInteger
+import java.security.PublicKey
+import java.security.Signature
+import java.security.interfaces.ECPublicKey
+
+private const val ECDSA_SIGNATURE_LENGTH = 64
+
+abstract class ECDSASignatureVerifier : SignatureVerifier {
+
+    abstract val algorithmName: String
+    abstract val validCurves: List<String>
+
+    override fun verify(
+        publicKey: PublicKey,
+        signData: ByteArray,
+        signature: ByteArray?,
+        provider: BouncyCastleProvider?
+    ): Boolean {
+        val ecKey = publicKey as? ECPublicKey ?: throw SignatureVerificationException("Provided key is not an Elliptic Curve key")
+        val params = ecKey.params
+        val curveName = (params as? ECNamedCurveSpec)?.name ?: params?.toString()
+        if (curveName == null) {
+            throw SignatureVerificationException("Unable to determine curve name for $algorithmName validation")
+        }
+        if (validCurves.none { curveName.contains(it, ignoreCase = true) }) {
+            throw SignatureVerificationException("Key curve '$curveName' does not match proof type $algorithmName")
+        }
+        if (signature == null || signature.size != ECDSA_SIGNATURE_LENGTH) {
+            throw SignatureVerificationException("Invalid signature length: Expected 64 bytes for R || S format")
+        }
+
+        try {
+            val derSignature = convertRawSignatureToDER(signature) // Convert to ASN.1 DER
+
+            Signature.getInstance(
+                CredentialVerifierConstants.EC_ALGORITHM,
+                provider ?: bouncyCastleProvider
+            )
+                .apply {
+                    initVerify(publicKey)
+                    update(signData)
+                    return verify(derSignature)
+                }
+        } catch (e: Exception) {
+            throw SignatureVerificationException("Error while doing signature verification using $algorithmName algorithm: ${e.message}")
+        }
+    }
+
+    /**
+     * Converts a raw ECDSA (R || S) signature (64 bytes) into ASN.1 DER format.
+     *
+     * ASN.1 DER Format:
+     *  - 0x30 (Sequence)
+     *  - Total length
+     *  - 0x02 (Integer marker) + Length of R + R value
+     *  - 0x02 (Integer marker) + Length of S + S value
+     *
+     */
+    private fun convertRawSignatureToDER(signature: ByteArray): ByteArray {
+        val r = BigInteger(1, signature.copyOfRange(0, ECDSA_SIGNATURE_LENGTH / 2))
+        val s = BigInteger(1, signature.copyOfRange(ECDSA_SIGNATURE_LENGTH / 2, ECDSA_SIGNATURE_LENGTH))
+
+        val outputStream = ByteArrayOutputStream()
+        val derEncoder = java.io.DataOutputStream(outputStream)
+
+        derEncoder.writeByte(0x30)
+        val seqBytes = ByteArrayOutputStream()
+
+        seqBytes.write(0x02)
+        seqBytes.write(r.toByteArray().size)
+        seqBytes.write(r.toByteArray())
+
+        seqBytes.write(0x02)
+        seqBytes.write(s.toByteArray().size)
+        seqBytes.write(s.toByteArray())
+
+        val derSeq = seqBytes.toByteArray()
+        derEncoder.write(derSeq.size)
+        derEncoder.write(derSeq)
+
+        return outputStream.toByteArray()
+    }
+}

--- a/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/signature/impl/ECDSASignatureVerifier.kt
+++ b/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/signature/impl/ECDSASignatureVerifier.kt
@@ -31,7 +31,8 @@ abstract class ECDSASignatureVerifier : SignatureVerifier {
         if (curveName == null) {
             throw SignatureVerificationException("Unable to determine curve name for $algorithmName validation")
         }
-        if (validCurves.none { curveName.contains(it, ignoreCase = true) }) {
+        val normalizedCurve = curveName.lowercase()
+        if (validCurves.none { normalizedCurve.contains(it, ignoreCase = true) }) {
             throw SignatureVerificationException("Key curve '$curveName' does not match proof type $algorithmName")
         }
         if (signature == null || signature.size != ECDSA_SIGNATURE_LENGTH) {
@@ -51,7 +52,7 @@ abstract class ECDSASignatureVerifier : SignatureVerifier {
                     return verify(derSignature)
                 }
         } catch (e: Exception) {
-            throw SignatureVerificationException("Error while doing signature verification using $algorithmName algorithm: ${e.message}")
+            throw SignatureVerificationException("Error while doing signature verification using $algorithmName algorithm: $e")
         }
     }
 

--- a/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/signature/impl/ES256KSignatureVerifierImpl.kt
+++ b/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/signature/impl/ES256KSignatureVerifierImpl.kt
@@ -1,77 +1,9 @@
 package io.mosip.vercred.vcverifier.signature.impl
 
-import io.mosip.vercred.vcverifier.constants.CredentialVerifierConstants
-import io.mosip.vercred.vcverifier.exception.SignatureVerificationException
-import io.mosip.vercred.vcverifier.signature.SignatureVerifier
-import io.mosip.vercred.vcverifier.signature.bouncyCastleProvider
-import org.bouncycastle.jce.provider.BouncyCastleProvider
-import java.io.ByteArrayOutputStream
-import java.math.BigInteger
-import java.security.PublicKey
-import java.security.Signature
+import io.mosip.vercred.vcverifier.constants.CredentialVerifierConstants.JWS_ES256K_SIGN_ALGO_CONST
+import io.mosip.vercred.vcverifier.constants.CredentialVerifierConstants.SECP256K1
 
-private const val ECDSA_SIGNATURE_LENGTH = 64
-
-class ES256KSignatureVerifierImpl : SignatureVerifier {
-    override fun verify(
-        publicKey: PublicKey,
-        signData: ByteArray,
-        signature: ByteArray?,
-        provider: BouncyCastleProvider?
-    ): Boolean {
-        if (signature == null || signature.size != ECDSA_SIGNATURE_LENGTH) {
-            throw SignatureVerificationException("Invalid signature length: Expected 64 bytes for R || S format")
-        }
-
-        try {
-            val derSignature = convertRawSignatureToDER(signature) // Convert to ASN.1 DER
-
-            Signature.getInstance(
-                CredentialVerifierConstants.EC_ALGORITHM,
-                provider ?: bouncyCastleProvider
-            )
-                .apply {
-                    initVerify(publicKey)
-                    update(signData)
-                    return verify(derSignature)
-                }
-        } catch (e: Exception) {
-            throw SignatureVerificationException("Error while doing signature verification using ES256K algorithm: ${e.message}")
-        }
-    }
-
-    /**
-     * Converts a raw ECDSA (R || S) signature (64 bytes) into ASN.1 DER format.
-     *
-     * ASN.1 DER Format:
-     *  - 0x30 (Sequence)
-     *  - Total length
-     *  - 0x02 (Integer marker) + Length of R + R value
-     *  - 0x02 (Integer marker) + Length of S + S value
-     *
-     */
-    private fun convertRawSignatureToDER(signature: ByteArray): ByteArray {
-        val r = BigInteger(1, signature.copyOfRange(0, ECDSA_SIGNATURE_LENGTH/2))
-        val s = BigInteger(1, signature.copyOfRange(ECDSA_SIGNATURE_LENGTH/2, ECDSA_SIGNATURE_LENGTH))
-
-        val outputStream = ByteArrayOutputStream()
-        val derEncoder = java.io.DataOutputStream(outputStream)
-
-        derEncoder.writeByte(0x30)
-        val seqBytes = ByteArrayOutputStream()
-
-        seqBytes.write(0x02)
-        seqBytes.write(r.toByteArray().size)
-        seqBytes.write(r.toByteArray())
-
-        seqBytes.write(0x02)
-        seqBytes.write(s.toByteArray().size)
-        seqBytes.write(s.toByteArray())
-
-        val derSeq = seqBytes.toByteArray()
-        derEncoder.write(derSeq.size)
-        derEncoder.write(derSeq)
-
-        return outputStream.toByteArray()
-    }
+class ES256KSignatureVerifierImpl : ECDSASignatureVerifier() {
+    override val algorithmName: String = JWS_ES256K_SIGN_ALGO_CONST
+    override val validCurves: List<String> = listOf(SECP256K1)
 }

--- a/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/signature/impl/ES256SignatureVerifierImpl.kt
+++ b/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/signature/impl/ES256SignatureVerifierImpl.kt
@@ -1,0 +1,11 @@
+package io.mosip.vercred.vcverifier.signature.impl
+
+import io.mosip.vercred.vcverifier.constants.CredentialVerifierConstants.JWS_ES256_SIGN_ALGO_CONST
+import io.mosip.vercred.vcverifier.constants.CredentialVerifierConstants.P256
+import io.mosip.vercred.vcverifier.constants.CredentialVerifierConstants.PRIME256V1
+import io.mosip.vercred.vcverifier.constants.CredentialVerifierConstants.SECP256R1
+
+class ES256SignatureVerifierImpl : ECDSASignatureVerifier() {
+    override val algorithmName: String = JWS_ES256_SIGN_ALGO_CONST
+    override val validCurves: List<String> = listOf(P256, SECP256R1, PRIME256V1)
+}

--- a/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/utils/LocalDocumentLoader.kt
+++ b/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/utils/LocalDocumentLoader.kt
@@ -46,6 +46,12 @@ object LocalDocumentLoader : ConfigurableDocumentLoader() {
                 "/contexts/mock-identity-context.json"
             url.toString().contains("https://inji.github.io/inji-config/contexts/farmer.json") ->
                 "/contexts/farmer-context-inji.json"
+            url.toString().contains("https://api.released.mosip.net/.well-known/mosip-ida-context.json") ->
+                "/contexts/mosip-ida-context-2.json"
+            url.toString().contains("https://inji.github.io/inji-config/contexts/mosip-identity-context.json") ->
+                "/contexts/mosip-identity-context-2.json"
+            url.toString().contains("https://inji.github.io/inji-config/contexts/insurance-context.json") ->
+                "/contexts/insurance-context-2.json"
             else -> throw IllegalArgumentException("Unexpected context: $url")
         }
     }

--- a/vc-verifier/kotlin/vcverifier/src/test/java/io/mosip/vercred/vcverifier/PresentationVerifierTest.kt
+++ b/vc-verifier/kotlin/vcverifier/src/test/java/io/mosip/vercred/vcverifier/PresentationVerifierTest.kt
@@ -169,6 +169,28 @@ class PresentationVerifierTest {
 
     @Test
     @Timeout(20, unit = TimeUnit.SECONDS)
+    fun `V2 should return success for valid ES256AlgorithmVP`() {
+        val vp = readClasspathFile("vp/ES256AlgorithmVP.json")
+
+        val result = PresentationVerifier().verifyV2(vp)
+
+        assertTrue(result.proofVerificationResult.verificationStatus)
+        assertEquals("", result.proofVerificationResult.verificationErrorCode)
+    }
+
+    @Test
+    @Timeout(20, unit = TimeUnit.SECONDS)
+    fun `V2 should return success for valid ES256KAlgorithmVP`() {
+        val vp = readClasspathFile("vp/ES256KAlgorithmVP.json")
+
+        val result = PresentationVerifier().verifyV2(vp)
+
+        assertTrue(result.proofVerificationResult.verificationStatus)
+        assertEquals("", result.proofVerificationResult.verificationErrorCode)
+    }
+
+    @Test
+    @Timeout(20, unit = TimeUnit.SECONDS)
     fun `V2 should return success for valid JsonWebSignature2020 VP`() {
         mockHttpResponse(
             "https://api.released.mosip.net/identity-service/02b073b8-aacd-472e-b63f-265bb7ccdd9f/did.json",
@@ -203,8 +225,7 @@ class PresentationVerifierTest {
 
         assertThrows<UnsupportedDidUrl> { PresentationVerifier().verifyV2(vp) }
     }
-
-
+    
     @Test
     fun `V2 should throw error when VP is not JSON-LD`() {
         assertThrows<PresentationNotSupportedException> {

--- a/vc-verifier/kotlin/vcverifier/src/test/java/io/mosip/vercred/vcverifier/PresentationVerifierTest.kt
+++ b/vc-verifier/kotlin/vcverifier/src/test/java/io/mosip/vercred/vcverifier/PresentationVerifierTest.kt
@@ -170,23 +170,33 @@ class PresentationVerifierTest {
     @Test
     @Timeout(20, unit = TimeUnit.SECONDS)
     fun `V2 should return success for valid ES256AlgorithmVP`() {
+        mockHttpResponse(
+            "https://api.released.mosip.net/identity-service/02b073b8-aacd-472e-b63f-265bb7ccdd9f/did.json",
+            readClasspathFile("vp/public_key/didIdentityServiceKey.json")
+        )
         val vp = readClasspathFile("vp/ES256AlgorithmVP.json")
 
         val result = PresentationVerifier().verifyV2(vp)
 
         assertTrue(result.proofVerificationResult.verificationStatus)
         assertEquals("", result.proofVerificationResult.verificationErrorCode)
+        assertTrue(result.vcResults[0].verificationResult.verificationStatus)
     }
 
     @Test
     @Timeout(20, unit = TimeUnit.SECONDS)
     fun `V2 should return success for valid ES256KAlgorithmVP`() {
+        mockHttpResponse(
+            "https://api.released.mosip.net/identity-service/02b073b8-aacd-472e-b63f-265bb7ccdd9f/did.json",
+            readClasspathFile("vp/public_key/didIdentityServiceKey.json")
+        )
         val vp = readClasspathFile("vp/ES256KAlgorithmVP.json")
 
         val result = PresentationVerifier().verifyV2(vp)
 
         assertTrue(result.proofVerificationResult.verificationStatus)
         assertEquals("", result.proofVerificationResult.verificationErrorCode)
+        assertTrue(result.vcResults[0].verificationResult.verificationStatus)
     }
 
     @Test

--- a/vc-verifier/kotlin/vcverifier/src/test/resources/contexts/insurance-context-2.json
+++ b/vc-verifier/kotlin/vcverifier/src/test/resources/contexts/insurance-context-2.json
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@protected": true,
+    "type": "@type",
+    "schema": "https://schema.org/",
+    "InsuranceCredential": {
+      "@id": "https://inji.github.io/inji-config/contexts/insurance-context.json#InsuranceCredential"
+    },
+    "dob": "schema:birthDate",
+    "email": "schema:email",
+    "gender": "schema:gender",
+    "mobile": "schema:telephone",
+    "benefits": "schema:benefits",
+    "fullName": "schema:name",
+    "policyExpiresOn": "schema:expires",
+    "policyIssuedOn": "schema:DateTime",
+    "policyName": "schema:Text",
+    "policyNumber": "schema:Text"
+  }
+}

--- a/vc-verifier/kotlin/vcverifier/src/test/resources/contexts/mosip-ida-context-2.json
+++ b/vc-verifier/kotlin/vcverifier/src/test/resources/contexts/mosip-ida-context-2.json
@@ -1,0 +1,84 @@
+{
+  "@context": [
+    {
+      "@version": 1.1
+    },
+    "https://www.w3.org/ns/odrl.jsonld",
+    {
+      "mosip": "https://api.released.mosip.net/mosip#",
+      "schema": "http://schema.org/",
+      "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+      "vcVer": "mosip:vcVer",
+      "UIN": "mosip:UIN",
+      "VID": "mosip:VID",
+      "addressLine1": {
+        "@id": "https://api.released.mosip.net/mosip#addressLine1",
+        "@context": {
+          "value": "rdf:value",
+          "lang": "@language"
+        }
+      },
+      "addressLine2": {
+        "@id": "https://api.released.mosip.net/mosip#addressLine2",
+        "@context": {
+          "value": "rdf:value",
+          "lang": "@language"
+        }
+      },
+      "addressLine3": {
+        "@id": "https://api.released.mosip.net/mosip#addressLine3",
+        "@context": {
+          "value": "rdf:value",
+          "lang": "@language"
+        }
+      },
+      "city": {
+        "@id": "https://api.released.mosip.net/mosip#city",
+        "@context": {
+          "value": "rdf:value",
+          "lang": "@language"
+        }
+      },
+      "gender": {
+        "@id": "https://api.released.mosip.net/mosip#gender",
+        "@context": {
+          "value": "rdf:value",
+          "lang": "@language"
+        }
+      },
+      "residenceStatus": {
+        "@id": "https://api.released.mosip.net/mosip#residenceStatus",
+        "@context": {
+          "value": "rdf:value",
+          "lang": "@language"
+        }
+      },
+      "dateOfBirth": "mosip:dateOfBirth",
+      "email": "mosip:email",
+      "fullName": {
+        "@id": "https://api.released.mosip.net/mosip#fullName",
+        "@context": {
+          "value": "rdf:value",
+          "lang": "@language"
+        }
+      },
+      "phone": "mosip:phone",
+      "postalCode": "mosip:postalCode",
+      "province": {
+        "@id": "https://api.released.mosip.net/mosip#province",
+        "@context": {
+          "value": "rdf:value",
+          "lang": "@language"
+        }
+      },
+      "region": {
+        "@id": "https://api.released.mosip.net/mosip#region",
+        "@context": {
+          "value": "rdf:value",
+          "lang": "@language"
+        }
+      },
+      "face": "mosip:face"
+    }
+  ]
+}

--- a/vc-verifier/kotlin/vcverifier/src/test/resources/contexts/mosip-identity-context-2.json
+++ b/vc-verifier/kotlin/vcverifier/src/test/resources/contexts/mosip-identity-context-2.json
@@ -1,0 +1,106 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@protected": true,
+    "type": "@type",
+    "schema": "https://schema.org/",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "mosipid": "https://inji.github.io/inji-config/contexts/mosip-identity-context.json#",
+    "MOSIPVerifiableCredential": {
+      "@id": "mosipid:MOSIPVerifiableCredential"
+    },
+    "vcVer": "mosipid:vcVer",
+    "UIN": "schema:identifier",
+    "VID": "mosipid:VID",
+    "fullName": {
+      "@id": "schema:name",
+      "@container": "@set",
+      "@context": {
+        "language": "@language",
+        "value": "@value"
+      }
+    },
+    "gender": {
+      "@id": "schema:gender",
+      "@container": "@set",
+      "@context": {
+        "language": "@language",
+        "value": "@value"
+      }
+    },
+    "dateOfBirth": {
+      "@id": "schema:birthDate",
+      "@type": "xsd:date"
+    },
+    "email": "schema:email",
+    "phone": "schema:telephone",
+    "postalCode": "schema:postalCode",
+    "residenceStatus": {
+      "@id": "schema:additionalType",
+      "@container": "@set",
+      "@context": {
+        "language": "@language",
+        "value": "@value"
+      }
+    },
+    "addressLine1": {
+      "@id": "schema:streetAddress",
+      "@container": "@set",
+      "@context": {
+        "language": "@language",
+        "value": "@value"
+      }
+    },
+    "addressLine2": {
+      "@id": "schema:streetAddress",
+      "@container": "@set",
+      "@context": {
+        "language": "@language",
+        "value": "@value"
+      }
+    },
+    "addressLine3": {
+      "@id": "schema:streetAddress",
+      "@container": "@set",
+      "@context": {
+        "language": "@language",
+        "value": "@value"
+      }
+    },
+    "city": {
+      "@id": "schema:addressLocality",
+      "@container": "@set",
+      "@context": {
+        "language": "@language",
+        "value": "@value"
+      }
+    },
+    "province": {
+      "@id": "schema:addressRegion",
+      "@container": "@set",
+      "@context": {
+        "language": "@language",
+        "value": "@value"
+      }
+    },
+    "region": {
+      "@id": "schema:addressRegion",
+      "@container": "@set",
+      "@context": {
+        "language": "@language",
+        "value": "@value"
+      }
+    },
+    "face": "schema:image",
+    "compressedFace": "schema:image",
+    "identityQRCode": "schema:Text",
+    "faceQRCode": "schema:Text",
+    "addressQRCode": "schema:Text",
+    "birthQRCode": "schema:Text",
+    "claim169": {
+      "@id": "mosipid:claim169",
+      "@container": "@index",
+      "@type": "schema:Text"
+    }
+  }
+}

--- a/vc-verifier/kotlin/vcverifier/src/test/resources/vp/ES256AlgorithmVP.json
+++ b/vc-verifier/kotlin/vcverifier/src/test/resources/vp/ES256AlgorithmVP.json
@@ -1,0 +1,58 @@
+{
+  "verifiableCredential": [
+    {
+      "issuer": "did:web:api.released.mosip.net:identity-service:02b073b8-aacd-472e-b63f-265bb7ccdd9f",
+      "credentialSubject": {
+        "dob": "2025-01-01",
+        "policyExpiresOn": "2033-04-20",
+        "policyIssuedOn": "2023-04-20",
+        "id": "did:jwk:eyJrdHkiOiJFQyIsInVzZSI6InNpZyIsImNydiI6IlAtMjU2IiwieCI6IkI3X0dpOFRhc3JPQ3d3d2xUbnZqUEtXY0d0empKTndBZUlTcVBLYm1wYVEiLCJ5IjoiSkVwNjFlbmE5NlNzc2JGOVlSV0xoZG1HNEtqY0JhTExmTFNqR2E3eXAwSSJ9",
+        "policyNumber": "5555",
+        "email": "abcd@gmail.com",
+        "policyName": "wallet",
+        "fullName": "wallet",
+        "mobile": "0123456789",
+        "benefits": [
+          "Critical Surgery",
+          "Full body checkup"
+        ],
+        "gender": "Male"
+      },
+      "id": "did:rcw:fe3c653d-e6f5-4a8f-b2b0-d2c3c1324231",
+      "proof": {
+        "created": "2026-03-23T12:29:13Z",
+        "verificationMethod": "did:web:api.released.mosip.net:identity-service:02b073b8-aacd-472e-b63f-265bb7ccdd9f#key-0",
+        "proofValue": "z5frV9G57p37N5dxJYPtNDUzPHZhvo4NHmH3MuXcAMeVLpLu5zSJSNtrs7np7zQaq2zje9u14npJVC1vMQVvyuBwY",
+        "type": "Ed25519Signature2020",
+        "proofPurpose": "assertionMethod"
+      },
+      "expirationDate": "2026-04-22T12:29:13.469Z",
+      "issuanceDate": "2026-03-23T12:29:13.478Z",
+      "@context": [
+        "https://www.w3.org/2018/credentials/v1",
+        "https://inji.github.io/inji-config/contexts/insurance-context.json",
+        "https://w3id.org/security/suites/ed25519-2020/v1"
+      ],
+      "type": [
+        "VerifiableCredential",
+        "InsuranceCredential"
+      ]
+    }
+  ],
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1",
+    "https://w3id.org/security/suites/jws-2020/v1"
+  ],
+  "proof": {
+    "type": "JsonWebSignature2020",
+    "verificationMethod": "did:jwk:eyJrdHkiOiJFQyIsImNydiI6IlAtMjU2IiwieCI6IkI3X0dpOFRhc3JPQ3d3d2xUbnZqUEtXY0d0empKTndBZUlTcVBLYm1wYVEiLCJ5IjoiSkVwNjFlbmE5NlNzc2JGOVlSV0xoZG1HNEtqY0JhTExmTFNqR2E3eXAwSSIsInVzZSI6InNpZyJ9#0",
+    "jws": "eyJhbGciOiJFUzI1NiIsImNyaXQiOlsiYjY0Il0sImI2NCI6ZmFsc2V9..wm81lyiEnjcTxAGE1LTbQDoxV2bnfv9K_ZOBv48WSostNvO2gjzUwsMljILVGvchN5RoZiFhId7Y62rK833FoQ",
+    "domain": "did:jwk:eyJrdHkiOiJFQyIsImNydiI6IlAtMjU2IiwieCI6IkI3X0dpOFRhc3JPQ3d3d2xUbnZqUEtXY0d0empKTndBZUlTcVBLYm1wYVEiLCJ5IjoiSkVwNjFlbmE5NlNzc2JGOVlSV0xoZG1HNEtqY0JhTExmTFNqR2E3eXAwSSIsInVzZSI6InNpZyJ9#0",
+    "challenge": "bGvxyRYPVQewlMOAaRvk0w=="
+  },
+  "holder": "did:jwk:eyJrdHkiOiJFQyIsImNydiI6IlAtMjU2IiwieCI6IkI3X0dpOFRhc3JPQ3d3d2xUbnZqUEtXY0d0empKTndBZUlTcVBLYm1wYVEiLCJ5IjoiSkVwNjFlbmE5NlNzc2JGOVlSV0xoZG1HNEtqY0JhTExmTFNqR2E3eXAwSSIsInVzZSI6InNpZyJ9#0",
+  "type": [
+    "VerifiablePresentation"
+  ],
+  "id": "urn:uuid:52640c74-50ba-4c3c-b14b-e919c2ff593c"
+}

--- a/vc-verifier/kotlin/vcverifier/src/test/resources/vp/ES256KAlgorithmVP.json
+++ b/vc-verifier/kotlin/vcverifier/src/test/resources/vp/ES256KAlgorithmVP.json
@@ -1,0 +1,58 @@
+{
+  "id": "urn:uuid:7c32c7fe-37b3-4f6e-8bcb-a208951f7b15",
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1",
+    "https://w3id.org/security/suites/jws-2020/v1"
+  ],
+  "type": [
+    "VerifiablePresentation"
+  ],
+  "verifiableCredential": [
+    {
+      "credentialSubject": {
+        "id": "did:jwk:eyJrdHkiOiJFQyIsInVzZSI6InNpZyIsImNydiI6InNlY3AyNTZrMSIsIngiOiJDRTRWQkRiUTBaODJ3Rnp4elNLN0lGcTF0Sl9ORVc5OTRrUkpicFVJU193IiwieSI6IlBNRUdJb3J2VlpLMnRZZlNRaVNYSlJscTlxWkhkdWZMWmtiZkNKdFBZWTQifQ==",
+        "fullName": "wallet",
+        "email": "abcd@gmail.com",
+        "policyExpiresOn": "2033-04-20",
+        "dob": "2025-01-01",
+        "benefits": [
+          "Critical Surgery",
+          "Full body checkup"
+        ],
+        "policyName": "wallet",
+        "gender": "Male",
+        "policyIssuedOn": "2023-04-20",
+        "policyNumber": "5555",
+        "mobile": "0123456789"
+      },
+      "issuer": "did:web:api.released.mosip.net:identity-service:02b073b8-aacd-472e-b63f-265bb7ccdd9f",
+      "@context": [
+        "https://www.w3.org/2018/credentials/v1",
+        "https://inji.github.io/inji-config/contexts/insurance-context.json",
+        "https://w3id.org/security/suites/ed25519-2020/v1"
+      ],
+      "proof": {
+        "proofPurpose": "assertionMethod",
+        "verificationMethod": "did:web:api.released.mosip.net:identity-service:02b073b8-aacd-472e-b63f-265bb7ccdd9f#key-0",
+        "proofValue": "z2MRv2jnWvyjWJMRzN4XvdSbNiAR9XrGC9dC23822oYSMfZpxe8THBkw2Tb3DGuGhAVZLxYKtpPib4zrZamb9LFSt",
+        "created": "2026-03-23T12:15:00Z",
+        "type": "Ed25519Signature2020"
+      },
+      "type": [
+        "VerifiableCredential",
+        "InsuranceCredential"
+      ],
+      "expirationDate": "2026-04-22T12:15:00.283Z",
+      "issuanceDate": "2026-03-23T12:15:00.289Z",
+      "id": "did:rcw:30c14fdf-6d9c-4b36-9a85-a5a3dc0bddd4"
+    }
+  ],
+  "holder": "did:jwk:eyJrdHkiOiJFQyIsImNydiI6InNlY3AyNTZrMSIsIngiOiJDRTRWQkRiUTBaODJ3Rnp4elNLN0lGcTF0Sl9ORVc5OTRrUkpicFVJU193IiwieSI6IlBNRUdJb3J2VlpLMnRZZlNRaVNYSlJscTlxWkhkdWZMWmtiZkNKdFBZWTQiLCJ1c2UiOiJzaWcifQ#0",
+  "proof": {
+    "verificationMethod": "did:jwk:eyJrdHkiOiJFQyIsImNydiI6InNlY3AyNTZrMSIsIngiOiJDRTRWQkRiUTBaODJ3Rnp4elNLN0lGcTF0Sl9ORVc5OTRrUkpicFVJU193IiwieSI6IlBNRUdJb3J2VlpLMnRZZlNRaVNYSlJscTlxWkhkdWZMWmtiZkNKdFBZWTQiLCJ1c2UiOiJzaWcifQ#0",
+    "challenge": "bGvxyRYPVQewlMOAaRvk0w==",
+    "domain": "did:jwk:eyJrdHkiOiJFQyIsImNydiI6InNlY3AyNTZrMSIsIngiOiJDRTRWQkRiUTBaODJ3Rnp4elNLN0lGcTF0Sl9ORVc5OTRrUkpicFVJU193IiwieSI6IlBNRUdJb3J2VlpLMnRZZlNRaVNYSlJscTlxWkhkdWZMWmtiZkNKdFBZWTQiLCJ1c2UiOiJzaWcifQ#0",
+    "type": "JsonWebSignature2020",
+    "jws": "eyJhbGciOiJFUzI1NksiLCJjcml0IjpbImI2NCJdLCJiNjQiOmZhbHNlfQ..dwhDS-BEiVYiLiF-g5JXJ7dMSsVAtOR9mMPwlSbEnFwvLnhyo7iGdkjev885pYpw9pr7PSNISpmrbiFrelk1zQ"
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for verifying presentations signed with ES256K and ES256 (in addition to EdDSA), with stricter EC curve validation and broader JWS algorithm handling.
  * Expanded JSON‑LD context mapping to recognize additional remote contexts during validation.

* **Tests**
  * Added test presentations and JSON‑LD context resources covering ES256K and ES256 verification scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->