### PR TITLE
#1984 Fix Holder Binding Validation Handling in vc-verifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,16 +100,25 @@ Verifiable Credentials they may contain.
 
 From Version `release-1.8.1` onwards, `PresentationVerifier.kt` includes improved holder binding validation handling for `did:key` and `did:jwk` DID methods in existing V1 and V2 verification APIs.
 
-The holder binding validation ensures:
+#### Holder binding validation ensures:
 
 1. `credentialSubject.id` is bound to `vp.holder`
 2. `vp.proof.verificationMethod` is controlled by `vp.holder` (Proof-of-Possession check)
 
-These validations are supported only for:
+#### Holder binding validation is supported only when:
+
+```text
+vp.holder
+```
+
+uses:
 - `did:key`
 - `did:jwk`
 
-Unsupported DID methods are skipped gracefully during holder binding validation.
+For supported holder DID methods:
+
+- unsupported DID methods in `credentialSubject.id` are skipped gracefully during subject-holder binding validation
+- unsupported or invalid DID methods in `vp.proof.verificationMethod` result in holder proof-of-possession validation failure
 
 ### Updated Validation Behavior
 

--- a/README.md
+++ b/README.md
@@ -97,16 +97,16 @@ Verifiable Credentials they may contain.
 2. Added **Holder Binding Check Support**  in `PresentationVerifier.kt`.
 
 ### Holder Binding Validation
-
+---
 From Version `release-1.8.1` onwards, `PresentationVerifier.kt` includes improved holder binding validation handling for `did:key` and `did:jwk` DID methods in existing V1 and V2 verification APIs.
 
-#### Holder binding validation ensures:
-
+#### Holder binding validation ensures
+---
 1. `credentialSubject.id` is bound to `vp.holder`
 2. `vp.proof.verificationMethod` is controlled by `vp.holder` (Proof-of-Possession check)
 
-#### Holder binding validation is supported only when:
-
+#### Holder binding validation is supported only when
+---
 ```text
 vp.holder
 ```
@@ -117,11 +117,25 @@ uses:
 
 For supported holder DID methods:
 
-- unsupported DID methods in `credentialSubject.id` are skipped gracefully during subject-holder binding validation
-- unsupported or invalid DID methods in `vp.proof.verificationMethod` result in holder proof-of-possession validation failure
+- Unsupported DID methods in `credentialSubject.id` are skipped gracefully during subject-holder binding validation
+- Unsupported or invalid DID methods in `vp.proof.verificationMethod` result in holder proof-of-possession validation failure
+
+#### Holder Binding Policy
+---
+The verifier validates:
+- VP proof ownership using the VP proof `verificationMethod`
+- Holder binding between the VP holder and `credentialSubject.id` when present
+
+| Scenario | Result |
+|---|---|
+| VP proof `verificationMethod` does not match VP holder | VP verification fails |
+| `credentialSubject.id` matches VP holder | Pass |
+| `credentialSubject.id` mismatches VP holder | VP verification fails |
+| `credentialSubject.id` missing | Holder binding check skipped |
+| Unsupported DID method | Holder binding check skipped |
 
 ### Updated Validation Behavior
-
+---
 Holder binding validation is applied in:
 
 ```kotlin
@@ -136,9 +150,9 @@ verifyAndGetCredentialStatusV2()
 
 From `release-1.8.1` onwards:
 
-- holder binding validation failures in form of `HolderBindingException` is no longer exposed through public functions
-- failures are returned as structured verification failures
-- verification messages are propagated through verification results
+- `HolderBindingException` is no longer exposed through public verification APIs
+- Holder binding failures are returned as structured verification failures
+- Verification messages are propagated through verification results
 
 Validation failures result in:
 
@@ -152,19 +166,18 @@ or:
 VerificationResult.verificationStatus = false
 ```
 
-depending on the function being used.
+depending on the API being used.
 
 ### Validation Coverage
-
+---
 The following validations are covered:
 
-- missing holder
-- missing `credentialSubject.id`
-- malformed `did:jwk`
-- unsupported key type
-- holder-subject mismatch
-- invalid proof-of-possession (`verificationMethod` not controlled by `vp.holder`)
-
+- Missing holder
+- Missing `credentialSubject.id`
+- Malformed `did:jwk`
+- Unsupported key type
+- Holder-subject mismatch
+- Invalid proof-of-possession (`verificationMethod` not controlled by `vp.holder`)
 ---
 
 # Integrating jar to Maven Project

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 
 ## 🚨 Breaking Changes
 
-### From Version `release-1.5.x` onward:
-
+### From Version `release-1.5.x` onwards:
+---
 #### ❗ Required Update in Imports
 
 Replace:
@@ -88,11 +88,77 @@ related to validating and verifying Verifiable Credentials (VCs). It also perfor
 that focuses on the verification of Verifiable Presentations (VPs). This class provides methods and functionalities 
 specifically designed to handle the unique aspects of VPs, including their structure, proof mechanisms, and the embedded 
 Verifiable Credentials they may contain.
-- **From Version `release-1.8.x` onwards**:
-Added **Holder Binding Check** in `PresentationVerifier.kt` for `did:key` and `did:jwk` DID methods.
-Also added **ECC R1 and K1 support** in both `CredentialVerifier.kt` & `PresentationVerifier.kt`.
+---
 
-#### Integrating jar to Maven Project
+### From Version `release-1.8.x` onwards:
+---
+
+1. Added **ECC R1 and K1 support** in both `CredentialVerifier.kt` & `PresentationVerifier.kt`.
+2. Added **Holder Binding Check Support**  in `PresentationVerifier.kt`.
+
+### Holder Binding Validation
+
+From Version `release-1.8.1` onwards, `PresentationVerifier.kt` includes improved holder binding validation handling for `did:key` and `did:jwk` DID methods in existing V1 and V2 verification APIs.
+
+The holder binding validation ensures:
+
+1. `credentialSubject.id` is bound to `vp.holder`
+2. `vp.proof.verificationMethod` is controlled by `vp.holder` (Proof-of-Possession check)
+
+These validations are supported only for:
+- `did:key`
+- `did:jwk`
+
+Unsupported DID methods are skipped gracefully during holder binding validation.
+
+### Updated Validation Behavior
+
+Holder binding validation is applied in:
+
+```kotlin
+verify()
+
+verifyV2()
+
+verifyAndGetCredentialStatus()
+
+verifyAndGetCredentialStatusV2()
+```
+
+From `release-1.8.1` onwards:
+
+- holder binding validation failures in form of `HolderBindingException` is no longer exposed through public functions
+- failures are returned as structured verification failures
+- verification messages are propagated through verification results
+
+Validation failures result in:
+
+```kotlin
+VPVerificationStatus.INVALID
+```
+
+or:
+
+```kotlin
+VerificationResult.verificationStatus = false
+```
+
+depending on the function being used.
+
+### Validation Coverage
+
+The following validations are covered:
+
+- missing holder
+- missing `credentialSubject.id`
+- malformed `did:jwk`
+- unsupported key type
+- holder-subject mismatch
+- invalid proof-of-possession (`verificationMethod` not controlled by `vp.holder`)
+
+---
+
+# Integrating jar to Maven Project
 
 
 ##### Add Vc-Verifier in `pom.xml`

--- a/vc-verifier/kotlin/vcverifier/publish-artifact.gradle
+++ b/vc-verifier/kotlin/vcverifier/publish-artifact.gradle
@@ -96,7 +96,7 @@ publishing {
             }
             groupId = "io.inji"
             artifactId = "vcverifier-aar"
-            version = "1.8.0"
+            version = "1.8.1-SNAPSHOT"
             if (project.gradle.startParameter.taskNames.any { it.contains('assembleRelease') }) {
                 artifacts {
                     aar {
@@ -110,7 +110,7 @@ publishing {
             artifact(tasks.named("jarRelease").get())
             groupId = "io.inji"
             artifactId = "vcverifier-jar"
-            version = "1.8.0"
+            version = "1.8.1-SNAPSHOT"
             artifact(tasks.named("javadocJar").get())
             artifact(tasks.named("sourcesJar").get())
             pom {

--- a/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/PresentationVerifier.kt
+++ b/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/PresentationVerifier.kt
@@ -330,6 +330,8 @@ class PresentationVerifier {
         }
     }
 
+    //TODO when DidKeyPublicKeyResolver/DidJwkPublicKeyResolver is extended to support RSA, generic EC, OKP
+    // along with current Ed25519, P-256 below code should be replaced with DidKeyPublicKeyResolver / DidJwkPublicKeyResolver
     private fun extractPublicKeyJson(input: String): JSONObject? {
         return when {
             input.startsWith("did:jwk:") -> {

--- a/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/PresentationVerifier.kt
+++ b/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/PresentationVerifier.kt
@@ -30,6 +30,8 @@ import io.mosip.vercred.vcverifier.constants.CredentialVerifierConstants.JSON_WE
 import io.mosip.vercred.vcverifier.constants.CredentialVerifierConstants.SUBJECT_ID_MISSING_MSG
 import io.mosip.vercred.vcverifier.constants.CredentialVerifierConstants.UNSUPPORTED_KEY_TYPE
 import io.mosip.vercred.vcverifier.constants.CredentialVerifierConstants.VERIFIABLE_CREDENTIAL_MISSING_MSG
+import io.mosip.vercred.vcverifier.constants.CredentialVerifierConstants.HOLDER_PROOF_MISSING_MSG
+import io.mosip.vercred.vcverifier.constants.CredentialVerifierConstants.INVALID_HOLDER_PROOF_MSG
 import io.mosip.vercred.vcverifier.constants.Shared.KEY_VERIFIABLE_CREDENTIAL
 import io.mosip.vercred.vcverifier.data.PresentationVerificationResult
 import io.mosip.vercred.vcverifier.data.PresentationResultWithCredentialStatus
@@ -77,7 +79,9 @@ class PresentationVerifier {
 
         val presentationVerificationStatus: VPVerificationStatus = getPresentationVerificationStatus(presentation)
 
-        val verifiableCredentials = JSONObject(presentation).getJSONArray(KEY_VERIFIABLE_CREDENTIAL)
+        val verifiableCredentials =
+            JSONObject(presentation).optJSONArray(KEY_VERIFIABLE_CREDENTIAL)
+                ?: JSONArray()
         val vcVerificationResults: List<VCResult> = getVCVerificationResults(verifiableCredentials)
 
         return PresentationVerificationResult(presentationVerificationStatus, vcVerificationResults)
@@ -87,7 +91,9 @@ class PresentationVerifier {
 
         val presentationVerificationResult: VerificationResult = getPresentationVerificationResult(presentation)
 
-        val verifiableCredentials = JSONObject(presentation).getJSONArray(KEY_VERIFIABLE_CREDENTIAL)
+        val verifiableCredentials =
+            JSONObject(presentation).optJSONArray(KEY_VERIFIABLE_CREDENTIAL)
+                ?: JSONArray()
         val vcVerificationResults: List<VCResultV2> = getVCVerificationResultsV2(verifiableCredentials)
 
         return PresentationVerificationResultV2(presentationVerificationResult, vcVerificationResults)
@@ -105,13 +111,16 @@ class PresentationVerifier {
 
         return try {
             if (verifyPresentationProof(vcJsonLdObject)) {
-                validateHolderBindingForDidKeyAndJwk(vcJsonLdObject)
-                VPVerificationStatus.VALID
+                //perform holder binding check
+                return if (validateHolderBindingForDidKeyAndJwk(vcJsonLdObject).verificationStatus)
+                    VPVerificationStatus.VALID
+                else
+                    VPVerificationStatus.INVALID
             }
             else
                 VPVerificationStatus.INVALID
         } catch (e: Exception) {
-            logger.severe("Error while verifying presentation : ${e.message}")
+            logger.severe("Error while verifying presentation proof : ${e.message}")
             when (e) {
                 is PublicKeyNotFoundException,
                 is IllegalStateException,
@@ -140,12 +149,8 @@ class PresentationVerifier {
             val isVerified = verifyPresentationProof(vcJsonLdObject)
 
             if (isVerified) {
-                validateHolderBindingForDidKeyAndJwk(vcJsonLdObject)
-                VerificationResult(
-                    true,
-                    "",
-                    ""
-                )
+                //perform holder binding check
+                return validateHolderBindingForDidKeyAndJwk(vcJsonLdObject)
             } else {
                 VerificationResult(
                     false,
@@ -161,8 +166,7 @@ class PresentationVerifier {
                 is UnsupportedDidUrl,
                 is InvalidKeySpecException,
                 is SignatureNotSupportedException,
-                is SignatureVerificationException,
-                is HolderBindingException -> throw e
+                is SignatureVerificationException -> throw e
 
                 else -> {
                     throw UnknownException("Error while doing verification of verifiable presentation")
@@ -171,103 +175,234 @@ class PresentationVerifier {
         }
     }
 
-    private fun validateHolderBindingForDidKeyAndJwk(vcJsonLdObject: JsonLDObject) {
-        val holderStr = vcJsonLdObject.jsonObject[HOLDER] as? String
-            ?: throw HolderBindingException(HOLDER_MISSING_MSG, HOLDER_VERIFICATION_FAIL_ERROR)
-        val holderPublicKeyJson = extractPublicKeyJson(holderStr) ?: run {
-            logger.info("Skipping holder binding: Method not supported for $holderStr")
-            return
-        }
+    private fun validateHolderBindingForDidKeyAndJwk(
+        vcJsonLdObject: JsonLDObject
+    ): VerificationResult {
 
-        val verifiableCredentials = vcJsonLdObject.jsonObject[KEY_VERIFIABLE_CREDENTIAL]
-            ?.let { it as? List<*> ?: listOf(it) }
-            ?: throw HolderBindingException(
-                VERIFIABLE_CREDENTIAL_MISSING_MSG,
-                HOLDER_VERIFICATION_FAIL_ERROR
-            )
+        val presentationVerified = VerificationResult(
+            true,
+            "",
+            ""
+        )
 
-        verifiableCredentials.filterIsInstance<Map<String, Any>>().forEach { credential ->
-            val credentialSubject = credential[CREDENTIAL_SUBJECT]
-            val subjects = when (credentialSubject) {
-                is Map<*, *> -> listOf(credentialSubject)
-                is List<*> -> credentialSubject.ifEmpty { null }
-                else -> null
-            } ?: throw HolderBindingException(
-                SUBJECT_ID_MISSING_MSG,
-                HOLDER_VERIFICATION_FAIL_ERROR
-            )
+        return try {
+            logger.info("Starting holder binding check")
+            val holderStr = vcJsonLdObject.jsonObject[HOLDER] as? String
+                ?: return VerificationResult(
+                    false,
+                    HOLDER_MISSING_MSG,
+                    HOLDER_VERIFICATION_FAIL_ERROR
+                )
 
-            subjects.forEach { subject ->
-                val subjectStr = (subject as? Map<*, *>)?.get(ID) as? String
+            val verifiableCredentials =
+                vcJsonLdObject.jsonObject[KEY_VERIFIABLE_CREDENTIAL]
+                    ?.let {
+                        val vcs = it as? List<*> ?: listOf(it)
+
+                        if (vcs.isEmpty()) {
+                            throw HolderBindingException(
+                                VERIFIABLE_CREDENTIAL_MISSING_MSG,
+                                HOLDER_VERIFICATION_FAIL_ERROR
+                            )
+                        }
+
+                        vcs
+                    }
                     ?: throw HolderBindingException(
-                        SUBJECT_ID_MISSING_MSG,
+                        VERIFIABLE_CREDENTIAL_MISSING_MSG,
                         HOLDER_VERIFICATION_FAIL_ERROR
                     )
-                val subjectPublicKeyJson = extractPublicKeyJson(subjectStr) ?: run {
-                    logger.info("Skipping subject binding check: Method not supported for $subjectStr")
-                    return@forEach
-                }
 
-                if (!comparePublicKeyJson(holderPublicKeyJson, subjectPublicKeyJson)) {
-                    throw HolderBindingException(
-                        HOLDER_MISMATCH_MSG.format(holderStr, subjectStr),
+            val holderPublicKeyJson = extractPublicKeyJson(holderStr)
+
+            if (holderPublicKeyJson == null) {
+                logger.info(
+                    "Skipping holder binding check: Method not supported for $holderStr"
+                )
+                return presentationVerified
+            }
+
+            validateHolderProofOfPossession(
+                vcJsonLdObject,
+                holderPublicKeyJson
+            )
+
+            verifiableCredentials.forEach { credentialObj ->
+
+                val credential = credentialObj as? Map<*, *>
+                    ?: throw HolderBindingException(
+                        VERIFIABLE_CREDENTIAL_MISSING_MSG,
                         HOLDER_VERIFICATION_FAIL_ERROR
                     )
+
+                val credentialSubject = credential[CREDENTIAL_SUBJECT]
+
+                val subjects = when (credentialSubject) {
+                    is Map<*, *> -> listOf(credentialSubject)
+                    is List<*> -> credentialSubject.ifEmpty { null }
+                    else -> null
+                } ?: throw HolderBindingException(
+                    SUBJECT_ID_MISSING_MSG,
+                    HOLDER_VERIFICATION_FAIL_ERROR
+                )
+
+                subjects.forEach subjectLoop@ { subject ->
+
+                    val subjectStr =
+                        (subject as? Map<*, *>)?.get(ID) as? String
+                            ?: throw HolderBindingException(
+                                SUBJECT_ID_MISSING_MSG,
+                                HOLDER_VERIFICATION_FAIL_ERROR
+                            )
+
+                    val subjectPublicKeyJson =
+                        extractPublicKeyJson(subjectStr) ?: run {
+
+                            logger.info(
+                                "Skipping subject binding check: " +
+                                        "Method not supported for $subjectStr"
+                            )
+
+                            return@subjectLoop
+                        }
+
+                    if (
+                        !comparePublicKeyJson(
+                            holderPublicKeyJson,
+                            subjectPublicKeyJson
+                        )
+                    ) {
+                        throw HolderBindingException(
+                            HOLDER_MISMATCH_MSG.format(
+                                holderStr,
+                                subjectStr
+                            ),
+                            HOLDER_VERIFICATION_FAIL_ERROR
+                        )
+                    }
                 }
             }
+
+            presentationVerified
+
+        } catch (e: HolderBindingException) {
+            logger.severe("Error while doing holder binding check, returning verification failed : ${e.errorCode} :  ${e.errorMessage}")
+            VerificationResult(
+                false,
+                e.errorMessage,
+                e.errorCode
+            )
+        }
+    }
+
+    private fun validateHolderProofOfPossession(
+        vcJsonLdObject: JsonLDObject,
+        holderPublicKeyJson: JSONObject
+    ) {
+        logger.info("Starting holder proof-of-possession check")
+        val proof = LdProof.getFromJsonLDObject(vcJsonLdObject)
+
+        val verificationMethod = proof.verificationMethod?.toString()
+            ?: throw HolderBindingException(
+                HOLDER_PROOF_MISSING_MSG,
+                HOLDER_VERIFICATION_FAIL_ERROR
+            )
+
+        val verificationMethodKeyJson =
+            extractPublicKeyJson(verificationMethod) ?: run {
+                logger.info(
+                    "Skipping proof-of-possession check: unsupported verificationMethod $verificationMethod"
+                )
+                return
+            }
+
+        if (!comparePublicKeyJson(holderPublicKeyJson, verificationMethodKeyJson)) {
+            throw HolderBindingException(
+                INVALID_HOLDER_PROOF_MSG,
+                HOLDER_VERIFICATION_FAIL_ERROR
+            )
         }
     }
 
     private fun extractPublicKeyJson(input: String): JSONObject? {
-        if (input.startsWith("did:jwk:")) {
-            val encodedJwk = input.removePrefix("did:jwk:").split('#', '?', ';')[0]
-            return try {
-                val base64UrlDecoder = Base64Decoder()
-                val jwkJson = String(base64UrlDecoder.decodeFromBase64Url(encodedJwk))
-                val parsedJwk = JWK.parse(jwkJson)
-                val publicJwk = parsedJwk.toPublicJWK()
-                JSONObject(publicJwk.toJSONObject())
-            } catch (e: HolderBindingException) {
-                throw e
-            } catch (_: Exception) {
-                throw HolderBindingException(FAILED_TO_DECODE, HOLDER_VERIFICATION_FAIL_ERROR)
-            }
-        }
-        if (input.startsWith("did:key:")) {
-            return try {
-                val methodSpecificId = input.removePrefix("did:key:").split('#', '?', ';')[0]
-                val decodedKey = Multibase.decode(methodSpecificId)
-                when {
-                    isEd25519KeyType(decodedKey) -> {
-                        val x = Base64URL.encode(decodedKey.copyOfRange(2, 34))
-                        JSONObject(OctetKeyPair.Builder(Curve.Ed25519, x).build().toJSONObject())
-                    }
-
-                    isP256KeyType(decodedKey) -> {
-                        val publicKeyBytes = decodedKey.copyOfRange(2, decodedKey.size)
-                        val decompressed = decompressP256Key(publicKeyBytes)
-                        val x = Base64URL.encode(decompressed.copyOfRange(1, 33))
-                        val y = Base64URL.encode(decompressed.copyOfRange(33, 65))
-                        val ecKey = ECKey.Builder(Curve.P_256, x, y).build()
-                        JSONObject(ecKey.toJSONObject())
-                    }
-
-                    else -> throw HolderBindingException(
-                        UNSUPPORTED_KEY_TYPE.format(decodedKey),
+        return when {
+            input.startsWith("did:jwk:") -> {
+                try {
+                    val encodedJwk = input
+                        .removePrefix("did:jwk:")
+                        .split('#', '?', ';')[0]
+                    val jwkJson = String(
+                        Base64Decoder().decodeFromBase64Url(encodedJwk)
+                    )
+                    val parsedJwk = JWK.parse(jwkJson)
+                    val publicJwk = parsedJwk.toPublicJWK()
+                    JSONObject(publicJwk.toJSONObject())
+                } catch (e: HolderBindingException) {
+                    throw e
+                } catch (e: Exception) {
+                    throw HolderBindingException(
+                        FAILED_TO_DECODE,
                         HOLDER_VERIFICATION_FAIL_ERROR
                     )
                 }
-            } catch (e: HolderBindingException) {
-                throw e
-            } catch (_: Exception) {
-                throw HolderBindingException(FAILED_TO_DECODE, HOLDER_VERIFICATION_FAIL_ERROR)
             }
+
+            input.startsWith("did:key:") -> {
+                try {
+                    val methodSpecificId = input
+                        .removePrefix("did:key:")
+                        .split('#', '?', ';')[0]
+
+                    val decodedKey = Multibase.decode(methodSpecificId)
+                    when {
+                        isEd25519KeyType(decodedKey) -> {
+                            val x = Base64URL.encode(
+                                decodedKey.copyOfRange(2, 34)
+                            )
+                            JSONObject(
+                                OctetKeyPair.Builder(Curve.Ed25519, x)
+                                    .build()
+                                    .toJSONObject()
+                            )
+                        }
+                        isP256KeyType(decodedKey) -> {
+                            val publicKeyBytes =
+                                decodedKey.copyOfRange(2, decodedKey.size)
+                            val decompressed =
+                                decompressP256Key(publicKeyBytes)
+                            val x = Base64URL.encode(
+                                decompressed.copyOfRange(1, 33)
+                            )
+                            val y = Base64URL.encode(
+                                decompressed.copyOfRange(33, 65)
+                            )
+                            JSONObject(
+                                ECKey.Builder(Curve.P_256, x, y)
+                                    .build()
+                                    .toJSONObject()
+                            )
+                        }
+                        else -> {
+                            throw HolderBindingException(
+                                UNSUPPORTED_KEY_TYPE.format(decodedKey),
+                                HOLDER_VERIFICATION_FAIL_ERROR
+                            )
+                        }
+                    }
+                } catch (e: HolderBindingException) {
+                    throw e
+                } catch (e: Exception) {
+                    throw HolderBindingException(
+                        FAILED_TO_DECODE,
+                        HOLDER_VERIFICATION_FAIL_ERROR
+                    )
+                }
+            }
+            else -> null
         }
-        return null
     }
 
     private fun comparePublicKeyJson(publicKeyJson1: JSONObject, publicKeyJson2: JSONObject): Boolean {
-        logger.info("publicKeyJson1: $publicKeyJson1, publicKeyJson2: $publicKeyJson2")
         val keyType = publicKeyJson1.optString("kty")
         if (keyType != publicKeyJson2.optString("kty")) return false
 
@@ -471,7 +606,9 @@ class PresentationVerifier {
     ): PresentationResultWithCredentialStatus {
         val presentationVerificationStatus = getPresentationVerificationStatus(presentation)
 
-        val verifiableCredentials = JSONObject(presentation).getJSONArray(KEY_VERIFIABLE_CREDENTIAL)
+        val verifiableCredentials =
+            JSONObject(presentation).optJSONArray(KEY_VERIFIABLE_CREDENTIAL)
+                ?: JSONArray()
         val vcVerificationResults: List<VCResultWithCredentialStatus> = getVCVerificationResultsWithCredentialStatus(verifiableCredentials, statusPurposeList)
 
         return PresentationResultWithCredentialStatus(presentationVerificationStatus, vcVerificationResults)
@@ -483,9 +620,12 @@ class PresentationVerifier {
     ): PresentationResultWithCredentialStatusV2 {
         val presentationVerificationResult = getPresentationVerificationResult(presentation)
 
-        val verifiableCredentials = JSONObject(presentation).getJSONArray(KEY_VERIFIABLE_CREDENTIAL)
+        val verifiableCredentials =
+            JSONObject(presentation).optJSONArray(KEY_VERIFIABLE_CREDENTIAL)
+                ?: JSONArray()
         val vcVerificationResults: List<VCResultWithCredentialStatusV2> = getVCVerificationResultsWithCredentialStatusV2(verifiableCredentials, statusPurposeList)
 
         return PresentationResultWithCredentialStatusV2(presentationVerificationResult, vcVerificationResults)
     }
+
 }

--- a/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/PresentationVerifier.kt
+++ b/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/PresentationVerifier.kt
@@ -250,10 +250,11 @@ class PresentationVerifier {
 
                     val subjectStr =
                         (subject as? Map<*, *>)?.get(ID) as? String
-                            ?: throw HolderBindingException(
-                                SUBJECT_ID_MISSING_MSG,
-                                HOLDER_VERIFICATION_FAIL_ERROR
-                            )
+
+                    if (subjectStr == null) {
+                        logger.info("Skipping subject binding check: subject.id missing")
+                        return@subjectLoop
+                    }
 
                     val subjectPublicKeyJson =
                         extractPublicKeyJson(subjectStr) ?: run {

--- a/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/PresentationVerifier.kt
+++ b/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/PresentationVerifier.kt
@@ -100,7 +100,7 @@ class PresentationVerifier {
     }
 
     private fun getPresentationVerificationStatus(presentation: String): VPVerificationStatus {
-        logger.info("Received Presentation For Verification - Start")
+        logger.info("Received Presentation For Verification - getPresentationVerificationStatus - Start")
         val vcJsonLdObject: JsonLDObject
 
         try {
@@ -137,7 +137,7 @@ class PresentationVerifier {
     }
 
     private fun getPresentationVerificationResult(presentation: String): VerificationResult {
-        logger.info("Received Presentation For Verification - Start")
+        logger.info("Received Presentation For Verification - getPresentationVerificationResult Start")
         val vcJsonLdObject: JsonLDObject
 
         try {
@@ -266,6 +266,7 @@ class PresentationVerifier {
                             return@subjectLoop
                         }
 
+
                     if (
                         !comparePublicKeyJson(
                             holderPublicKeyJson,
@@ -310,10 +311,14 @@ class PresentationVerifier {
 
         val verificationMethodKeyJson =
             extractPublicKeyJson(verificationMethod) ?: run {
-                logger.info(
-                    "Skipping proof-of-possession check: unsupported verificationMethod $verificationMethod"
+                logger.severe(
+                    "Invalid proof-of-possession verificationMethod $verificationMethod"
                 )
-                return
+
+                throw HolderBindingException(
+                    INVALID_HOLDER_PROOF_MSG,
+                    HOLDER_VERIFICATION_FAIL_ERROR
+                )
             }
 
         if (!comparePublicKeyJson(holderPublicKeyJson, verificationMethodKeyJson)) {

--- a/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/constants/CredentialVerifierConstants.kt
+++ b/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/constants/CredentialVerifierConstants.kt
@@ -67,4 +67,9 @@ object CredentialVerifierConstants {
 
     const val RSA_MULTICODEC_FIRST = 0x12.toByte()
     const val RSA_MULTICODEC_SECOND = 0x05.toByte()
+
+    const val HOLDER_PROOF_MISSING_MSG =
+        "VP proof verificationMethod is missing"
+    const val INVALID_HOLDER_PROOF_MSG =
+        "VP proof verificationMethod is not controlled by vp.holder"
 }

--- a/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/constants/CredentialVerifierConstants.kt
+++ b/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/constants/CredentialVerifierConstants.kt
@@ -52,7 +52,7 @@ object CredentialVerifierConstants {
     const val ERROR_MESSAGE_VERIFICATION_FAILED = "Verification Failed"
     const val ERROR_CODE_VERIFICATION_FAILED = "ERR_SIGNATURE_VERIFICATION_FAILED"
 
-    const val HOLDER_VERIFICATION_FAIL_ERROR = "Holder binding Verification Failed"
+    const val HOLDER_VERIFICATION_FAIL_ERROR = "ERR_HOLDER_BINDING_CHECK_FAILED"
     const val HOLDER_MISSING_MSG = "The Verifiable Presentation is missing a mandatory Holder ID"
     const val SUBJECT_ID_MISSING_MSG = "The Verifiable Credential is missing a mandatory Credential Subject ID"
     const val VERIFIABLE_CREDENTIAL_MISSING_MSG = "The Verifiable Presentation is missing a mandatory Verifiable Credential"

--- a/vc-verifier/kotlin/vcverifier/src/test/java/io/mosip/vercred/vcverifier/PresentationVerifierTest.kt
+++ b/vc-verifier/kotlin/vcverifier/src/test/java/io/mosip/vercred/vcverifier/PresentationVerifierTest.kt
@@ -28,11 +28,23 @@ import testutils.mockHttpResponse
 import testutils.readClasspathFile
 import java.util.concurrent.TimeUnit
 import io.mosip.vercred.vcverifier.data.PresentationResultWithCredentialStatusV2
-import io.mosip.vercred.vcverifier.exception.HolderBindingException
 import org.junit.jupiter.api.Assertions.assertNotEquals
+import io.mosip.vercred.vcverifier.constants.CredentialVerifierConstants.HOLDER_VERIFICATION_FAIL_ERROR
+import io.mosip.vercred.vcverifier.exception.HolderBindingException
+import org.junit.jupiter.api.Assertions.assertDoesNotThrow
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class PresentationVerifierTest {
+
+    private fun mockedVerifier(): PresentationVerifier {
+        val verifier = spyk(PresentationVerifier(), recordPrivateCalls = true)
+
+        every {
+            verifier["verifyPresentationProof"](any<JsonLDObject>())
+        } returns true
+
+        return verifier
+    }
 
     @BeforeAll
     fun setup() {
@@ -169,23 +181,13 @@ class PresentationVerifierTest {
         assertEquals("", result.proofVerificationResult.verificationErrorCode)
     }
 
-    @Test
-    @Timeout(20, unit = TimeUnit.SECONDS)
-    fun `V2 should return failed for invalid holder binding VP`() {
-        val vp = readClasspathFile("vp/InvalidHolderBindingVP.json")
-        val verifier = spyk(PresentationVerifier(), recordPrivateCalls = true)
-        every { verifier["verifyPresentationProof"](any<JsonLDObject>()) } returns true
 
-        assertThrows<HolderBindingException> { verifier.verifyV2(vp) }
-    }
 
     @Test
     @Timeout(20, unit = TimeUnit.SECONDS)
     fun `V2 should return success for valid jwk holder binding VP`() {
         val vp = readClasspathFile("vp/validJWKHolderBindingVP.json")
-        val verifier = spyk(PresentationVerifier(), recordPrivateCalls = true)
-        every { verifier["verifyPresentationProof"](any<JsonLDObject>()) } returns true
-
+        val verifier = mockedVerifier()
         val result = verifier.verifyV2(vp)
 
         assertTrue(result.proofVerificationResult.verificationStatus)
@@ -196,9 +198,7 @@ class PresentationVerifierTest {
     @Timeout(20, unit = TimeUnit.SECONDS)
     fun `V2 should skip holder binding for unSupported did VP`() {
         val vp = readClasspathFile("vp/webHolderBindingVP.json")
-        val verifier = spyk(PresentationVerifier(), recordPrivateCalls = true)
-        every { verifier["verifyPresentationProof"](any<JsonLDObject>()) } returns true
-
+        val verifier = mockedVerifier()
         val result = verifier.verifyV2(vp)
 
         assertTrue(result.proofVerificationResult.verificationStatus)
@@ -209,21 +209,11 @@ class PresentationVerifierTest {
     @Timeout(20, unit = TimeUnit.SECONDS)
     fun `verifyV2 should return success when VP holder did-key matches VC subject did-jwk`() {
         val vp = readClasspathFile("vp/crossMethodBindingVP.json")
-        val verifier = spyk(PresentationVerifier(), recordPrivateCalls = true)
-        every { verifier["verifyPresentationProof"](any<JsonLDObject>()) } returns true
-
+        val verifier = mockedVerifier()
         val result = verifier.verifyV2(vp)
 
         assertTrue(result.proofVerificationResult.verificationStatus)
         assertEquals("", result.proofVerificationResult.verificationErrorCode)
-    }
-
-    @Test
-    @Timeout(20, unit = TimeUnit.SECONDS)
-    fun `V2 should return failed for invalid jwk holder binding VP`() {
-        val vp = readClasspathFile("vp/InvalidJWKHolderBindingVP.json")
-
-        assertThrows<HolderBindingException> { PresentationVerifier().verifyV2(vp) }
     }
 
     @Test
@@ -375,87 +365,243 @@ class PresentationVerifierTest {
         assertNull(entry.value.error)
     }
 
-    @Test
-    fun `V2 should throw HolderBindingException when verifiableCredential is missing`() {
-        val vp = readClasspathFile("vp/vpWithMissingVerifiableCredential.json")
-
-        val verifier = spyk(PresentationVerifier(), recordPrivateCalls = true)
-        every { verifier["verifyPresentationProof"](any<JsonLDObject>()) } returns true
-
-        val exception = assertThrows<HolderBindingException> {
-            verifier.verifyV2(vp)
-        }
-        assertEquals("The Verifiable Presentation is missing a mandatory Verifiable Credential", exception.message)
-    }
-
-    @Test
-    fun `V2 should throw HolderBindingException when holder is missing`() {
-        val vp = readClasspathFile("vp/VPWithMissingHolder.json")
-        val verifier = spyk(PresentationVerifier(), recordPrivateCalls = true)
-        every { verifier["verifyPresentationProof"](any<JsonLDObject>()) } returns true
-
-        val exception = assertThrows<HolderBindingException> {
-            verifier.verifyV2(vp)
-        }
-        assertEquals("The Verifiable Presentation is missing a mandatory Holder ID", exception.message)
-    }
-
-    @Test
-    fun `V2 should throw HolderBindingException when credentialSubject is missing or empty`() {
-        val vp = readClasspathFile("vp/VPWithEmptySubject.json")
-        val verifier = spyk(PresentationVerifier(), recordPrivateCalls = true)
-        every { verifier["verifyPresentationProof"](any<JsonLDObject>()) } returns true
-
-        assertThrows<HolderBindingException> {
-            verifier.verifyV2(vp)
-        }
-    }
-
-    @Test
-    fun `V2 should throw HolderBindingException when subject ID is missing`() {
-        val vp = readClasspathFile("vp/VPWithSubjectMissingId.json")
-        val verifier = spyk(PresentationVerifier(), recordPrivateCalls = true)
-        every { verifier["verifyPresentationProof"](any<JsonLDObject>()) } returns true
-
-        assertThrows<HolderBindingException> {
-            verifier.verifyV2(vp)
-        }
-    }
-
-    @Test
-    fun `V2 should throw HolderBindingException when did-jwk is malformed`() {
-        val vp = readClasspathFile("vp/VPWithMalformedJwk.json")
-        val verifier = spyk(PresentationVerifier(), recordPrivateCalls = true)
-        every { verifier["verifyPresentationProof"](any<JsonLDObject>()) } returns true
-
-        val exception = assertThrows<HolderBindingException> {
-            verifier.verifyV2(vp)
-        }
-        assertEquals("Fail to decode input to extract public key", exception.message)
-    }
 
     @Test
     @Timeout(20, unit = TimeUnit.SECONDS)
     fun `V2 should handle P256 key type in did-key extraction`() {
         val vp = readClasspathFile("vp/P256HolderBindingVP.json")
-        val verifier = spyk(PresentationVerifier(), recordPrivateCalls = true)
-        every { verifier["verifyPresentationProof"](any<JsonLDObject>()) } returns true
-
+        val verifier = mockedVerifier()
         val result = verifier.verifyV2(vp)
         assertNotNull(result)
         assertTrue(result.proofVerificationResult.verificationStatus)
         assertEquals("", result.proofVerificationResult.verificationErrorCode)
     }
 
-    @Test
-    fun `V2 should throw HolderBindingException for unsupported multi-codec key type`() {
-        val vp = readClasspathFile("vp/UnsupportedKeyTypeVP.json")
-        val verifier = spyk(PresentationVerifier(), recordPrivateCalls = true)
-        every { verifier["verifyPresentationProof"](any<JsonLDObject>()) } returns true
+    //Below are testcase for Holder Binding Check
 
-        assertThrows<HolderBindingException> {
-            verifier.verifyV2(vp)
-        }
+    @Test
+    fun `V1 should return success for valid jwk holder binding VP`() {
+
+        val vp = readClasspathFile("vp/validJWKHolderBindingVP.json")
+
+        val verifier = mockedVerifier()
+
+        val result = verifier.verify(vp)
+
+        assertEquals(
+            VPVerificationStatus.VALID,
+            result.proofVerificationStatus
+        )
+    }
+
+    @Test
+    fun `V1 should verify credential status with valid holder proof`() {
+
+        val vp = readClasspathFile("vp/validJWKHolderBindingVP.json")
+
+        val verifier = mockedVerifier()
+
+        val result =
+            verifier.verifyAndGetCredentialStatus(
+                vp,
+                listOf("revocation")
+            )
+
+        assertEquals(
+            VPVerificationStatus.VALID,
+            result.proofVerificationStatus
+        )
+
+        assertEquals(1, result.vcResults.size)
+    }
+
+    @Test
+    fun `V1 should return failure when holder is missing`() {
+
+        val vp = readClasspathFile("vp/VPWithMissingHolder.json")
+
+        val verifier = mockedVerifier()
+
+        val result = verifier.verify(vp)
+
+        assertEquals(
+            VPVerificationStatus.INVALID,
+            result.proofVerificationStatus
+        )
+    }
+
+    @Test
+    fun `V1 should return failure for invalid holder binding VP`() {
+
+        val vp = readClasspathFile("vp/InvalidHolderBindingVP.json")
+
+        val verifier = mockedVerifier()
+
+        val result = verifier.verify(vp)
+
+        assertEquals(
+            VPVerificationStatus.INVALID,
+            result.proofVerificationStatus
+        )
+    }
+
+    @Test
+    fun `V1 should fail for malformed did-jwk`() {
+
+        val vp = readClasspathFile("vp/VPWithMalformedJwk.json")
+
+        val verifier = mockedVerifier()
+
+        val result = verifier.verify(vp)
+
+        assertEquals(
+            VPVerificationStatus.INVALID,
+            result.proofVerificationStatus
+        )
+    }
+
+    @Test
+    fun `V1 should fail for invalid holder proof`() {
+
+        val vp = readClasspathFile("vp/InvalidHolderBindingVP.json")
+
+        val verifier = mockedVerifier()
+
+        val result =
+            verifier.verifyAndGetCredentialStatus(
+                vp,
+                emptyList()
+            )
+
+        assertEquals(
+            VPVerificationStatus.INVALID,
+            result.proofVerificationStatus
+        )
+    }
+
+    @Test
+    fun `V2 should return failure when verifiableCredential is missing`() {
+        val vp = readClasspathFile("vp/vpWithMissingVerifiableCredential.json")
+
+        val verifier = mockedVerifier()
+        val result = verifier.verifyV2(vp)
+
+        assertFalse(result.proofVerificationResult.verificationStatus)
+        assertEquals(
+            HOLDER_VERIFICATION_FAIL_ERROR,
+            result.proofVerificationResult.verificationErrorCode
+        )
+    }
+
+    @Test
+    fun `V2 should return failure when holder is missing`() {
+        val vp = readClasspathFile("vp/VPWithMissingHolder.json")
+
+        val verifier = mockedVerifier()
+        val result = verifier.verifyV2(vp)
+
+        assertFalse(result.proofVerificationResult.verificationStatus)
+        assertEquals(
+            HOLDER_VERIFICATION_FAIL_ERROR,
+            result.proofVerificationResult.verificationErrorCode
+        )
+    }
+
+    @Test
+    fun `V2 should return failure when credentialSubject is missing or empty`() {
+        val vp = readClasspathFile("vp/VPWithEmptySubject.json")
+
+        val verifier = mockedVerifier()
+        val result = verifier.verifyV2(vp)
+
+        assertFalse(result.proofVerificationResult.verificationStatus)
+        assertEquals(
+            HOLDER_VERIFICATION_FAIL_ERROR,
+            result.proofVerificationResult.verificationErrorCode
+        )
+    }
+
+    @Test
+    fun `V2 should return failure when subject ID is missing`() {
+        val vp = readClasspathFile("vp/VPWithSubjectMissingId.json")
+
+        val verifier = mockedVerifier()
+        val result = verifier.verifyV2(vp)
+
+        assertFalse(result.proofVerificationResult.verificationStatus)
+        assertEquals(
+            HOLDER_VERIFICATION_FAIL_ERROR,
+            result.proofVerificationResult.verificationErrorCode
+        )
+    }
+
+    @Test
+    fun `V2 should return failure when did-jwk is malformed`() {
+        val vp = readClasspathFile("vp/VPWithMalformedJwk.json")
+
+        val verifier = mockedVerifier()
+        val result = verifier.verifyV2(vp)
+
+        assertFalse(result.proofVerificationResult.verificationStatus)
+        assertEquals(
+            HOLDER_VERIFICATION_FAIL_ERROR,
+            result.proofVerificationResult.verificationErrorCode
+        )
+        assertEquals(
+            "Fail to decode input to extract public key",
+            result.proofVerificationResult.verificationMessage
+        )
+    }
+
+    @Test
+    @Timeout(20, unit = TimeUnit.SECONDS)
+    fun `V2 should return failed for invalid jwk holder binding VP`() {
+
+        val vp = readClasspathFile("vp/InvalidJWKHolderBindingVP.json")
+
+        val verifier = spyk(PresentationVerifier(), recordPrivateCalls = true)
+
+        every {
+            verifier["verifyPresentationProof"](any<JsonLDObject>())
+        } returns true
+
+        val result = verifier.verifyV2(vp)
+
+        assertFalse(result.proofVerificationResult.verificationStatus)
+
+        assertEquals(
+            HOLDER_VERIFICATION_FAIL_ERROR,
+            result.proofVerificationResult.verificationErrorCode
+        )
+    }
+
+    @Test
+    @Timeout(20, unit = TimeUnit.SECONDS)
+    fun `V2 should return failed for invalid holder binding VP`() {
+        val vp = readClasspathFile("vp/InvalidHolderBindingVP.json")
+
+        val verifier = mockedVerifier()
+        val result = verifier.verifyV2(vp)
+
+        assertFalse(result.proofVerificationResult.verificationStatus)
+        assertEquals(
+            HOLDER_VERIFICATION_FAIL_ERROR,
+            result.proofVerificationResult.verificationErrorCode
+        )
+    }
+
+    @Test
+    fun `V2 should return failure for unsupported multi-codec key type`() {
+        val vp = readClasspathFile("vp/UnsupportedKeyTypeVP.json")
+
+        val verifier = mockedVerifier()
+        val result = verifier.verifyV2(vp)
+
+        assertFalse(result.proofVerificationResult.verificationStatus)
+        assertEquals(
+            HOLDER_VERIFICATION_FAIL_ERROR,
+            result.proofVerificationResult.verificationErrorCode
+        )
     }
 
     @Test
@@ -486,4 +632,311 @@ class PresentationVerifierTest {
         assertTrue(resultTrue)
         assertFalse(resultFalse)
     }
+
+    @Test
+    @Timeout(20, unit = TimeUnit.SECONDS)
+    fun `V2 should verify credential status with holder binding enabled`() {
+
+        val vp = readClasspathFile("vp/validJWKHolderBindingVP.json")
+
+        val verifier = spyk(PresentationVerifier(), recordPrivateCalls = true)
+
+        every {
+            verifier["verifyPresentationProof"](any<JsonLDObject>())
+        } returns true
+
+        val result =
+            verifier.verifyAndGetCredentialStatusV2(
+                vp,
+                listOf("revocation")
+            )
+
+        assertTrue(result.proofVerificationResult.verificationStatus)
+
+        assertEquals(
+            "",
+            result.proofVerificationResult.verificationErrorCode
+        )
+
+        assertEquals(1, result.vcResults.size)
+    }
+
+    @Test
+    fun `V2 credential status should fail for invalid holder proof`() {
+
+        val vp = readClasspathFile("vp/InvalidHolderBindingVP.json")
+
+        val verifier = spyk(PresentationVerifier(), recordPrivateCalls = true)
+
+        every {
+            verifier["verifyPresentationProof"](any<JsonLDObject>())
+        } returns true
+
+        val result =
+            verifier.verifyAndGetCredentialStatusV2(
+                vp,
+                emptyList()
+            )
+        assertFalse(result.proofVerificationResult.verificationStatus)
+
+        assertEquals(
+            HOLDER_VERIFICATION_FAIL_ERROR,
+            result.proofVerificationResult.verificationErrorCode
+        )
+    }
+
+    @Test
+    fun `validateHolderProofOfPossession should fail when proof is missing`() {
+
+        val verifier = PresentationVerifier()
+
+        val vpJson = org.json.JSONObject(
+            readClasspathFile("vp/validJWKHolderBindingVP.json")
+        )
+
+        vpJson.remove("proof")
+
+        val jsonLdObject =
+            JsonLDObject.fromJson(vpJson.toString())
+
+        val holderKey = org.json.JSONObject()
+            .put("kty", "OKP")
+            .put("crv", "Ed25519")
+            .put("x", "dummy")
+
+        val method =
+            verifier.javaClass.getDeclaredMethod(
+                "validateHolderProofOfPossession",
+                JsonLDObject::class.java,
+                org.json.JSONObject::class.java
+            )
+
+        method.isAccessible = true
+
+        assertThrows<java.lang.reflect.InvocationTargetException> {
+            method.invoke(verifier, jsonLdObject, holderKey)
+        }
+    }
+
+    @Test
+    fun `validateHolderProofOfPossession should succeed for matching holder proof`() {
+
+        val verifier = PresentationVerifier()
+
+        val vp =
+            readClasspathFile("vp/Ed25519Signature2018SignedVP-didKey.json")
+
+        val jsonLdObject = JsonLDObject.fromJson(vp)
+
+        val extractMethod =
+            verifier.javaClass.getDeclaredMethod(
+                "extractPublicKeyJson",
+                String::class.java
+            )
+
+        extractMethod.isAccessible = true
+
+        val holder =
+            jsonLdObject.jsonObject["holder"] as String
+
+        val holderKey =
+            extractMethod.invoke(verifier, holder) as org.json.JSONObject
+
+        val method =
+            verifier.javaClass.getDeclaredMethod(
+                "validateHolderProofOfPossession",
+                JsonLDObject::class.java,
+                org.json.JSONObject::class.java
+            )
+
+        method.isAccessible = true
+
+        method.invoke(verifier, jsonLdObject, holderKey)
+    }
+
+    @Test
+    fun `validateHolderProofOfPossession should fail for mismatched verificationMethod`() {
+
+        val verifier = PresentationVerifier()
+
+        val vp =
+            readClasspathFile("vp/InvalidHolderBindingVP.json")
+
+        val jsonLdObject = JsonLDObject.fromJson(vp)
+
+        val extractMethod =
+            verifier.javaClass.getDeclaredMethod(
+                "extractPublicKeyJson",
+                String::class.java
+            )
+
+        extractMethod.isAccessible = true
+
+        val holder =
+            jsonLdObject.jsonObject["holder"] as String
+
+        val holderKey =
+            extractMethod.invoke(verifier, holder) as org.json.JSONObject
+
+        val method =
+            verifier.javaClass.getDeclaredMethod(
+                "validateHolderProofOfPossession",
+                JsonLDObject::class.java,
+                org.json.JSONObject::class.java
+            )
+
+        method.isAccessible = true
+
+        val exception = assertThrows<java.lang.reflect.InvocationTargetException> {
+            method.invoke(verifier, jsonLdObject, holderKey)
+        }
+
+        val cause = exception.cause as HolderBindingException
+
+        assertEquals(
+            HOLDER_VERIFICATION_FAIL_ERROR,
+            cause.errorCode
+        )
+    }
+
+    @Test
+    fun `validateHolderProofOfPossession should fail when verificationMethod missing`() {
+
+        val verifier = PresentationVerifier()
+
+        val vpJson = org.json.JSONObject(
+            readClasspathFile("vp/validJWKHolderBindingVP.json")
+        )
+
+        vpJson.getJSONObject("proof").remove("verificationMethod")
+
+        val jsonLdObject =
+            JsonLDObject.fromJson(vpJson.toString())
+
+        val holderKey = org.json.JSONObject()
+            .put("kty", "OKP")
+            .put("crv", "Ed25519")
+            .put("x", "dummy")
+
+        val method =
+            verifier.javaClass.getDeclaredMethod(
+                "validateHolderProofOfPossession",
+                JsonLDObject::class.java,
+                org.json.JSONObject::class.java
+            )
+
+        method.isAccessible = true
+
+        val exception = assertThrows<java.lang.reflect.InvocationTargetException> {
+            method.invoke(verifier, jsonLdObject, holderKey)
+        }
+
+        val cause = exception.cause as HolderBindingException
+
+        assertEquals(
+            HOLDER_VERIFICATION_FAIL_ERROR,
+            cause.errorCode
+        )
+    }
+
+    @Test
+    fun `validateHolderProofOfPossession should fail for malformed verificationMethod`() {
+
+        val verifier = PresentationVerifier()
+
+        val vpJson = org.json.JSONObject(
+            readClasspathFile("vp/validJWKHolderBindingVP.json")
+        )
+
+        vpJson.getJSONObject("proof")
+            .put("verificationMethod", "did:jwk:invalid")
+
+        val jsonLdObject =
+            JsonLDObject.fromJson(vpJson.toString())
+
+        val holderKey = org.json.JSONObject()
+            .put("kty", "OKP")
+            .put("crv", "Ed25519")
+            .put("x", "dummy")
+
+        val method =
+            verifier.javaClass.getDeclaredMethod(
+                "validateHolderProofOfPossession",
+                JsonLDObject::class.java,
+                org.json.JSONObject::class.java
+            )
+
+        method.isAccessible = true
+
+        val exception = assertThrows<java.lang.reflect.InvocationTargetException> {
+            method.invoke(verifier, jsonLdObject, holderKey)
+        }
+
+        val cause = exception.cause as HolderBindingException
+
+        assertEquals(
+            HOLDER_VERIFICATION_FAIL_ERROR,
+            cause.errorCode
+        )
+    }
+
+    @Test
+    fun `validateHolderProofOfPossession should skip unsupported DID method`() {
+
+        val verifier = PresentationVerifier()
+
+        val vpJson = org.json.JSONObject(
+            readClasspathFile("vp/Ed25519Signature2018SignedVP-didKey.json")
+        )
+
+        vpJson.getJSONObject("proof")
+            .put(
+                "verificationMethod",
+                "did:web:example.com#key-1"
+            )
+
+        val jsonLdObject =
+            JsonLDObject.fromJson(vpJson.toString())
+
+        val holderKey = org.json.JSONObject()
+            .put("kty", "OKP")
+            .put("crv", "Ed25519")
+            .put("x", "dummy")
+
+        val method =
+            verifier.javaClass.getDeclaredMethod(
+                "validateHolderProofOfPossession",
+                JsonLDObject::class.java,
+                org.json.JSONObject::class.java
+            )
+
+        method.isAccessible = true
+
+        assertDoesNotThrow {
+            method.invoke(verifier, jsonLdObject, holderKey)
+        }
+    }
+
+    @Test
+    fun `V2 should return failure when verifiableCredential array is empty`() {
+
+        val vp = readClasspathFile("vp/EmptyVerifiableCredentialVP.json")
+
+        val verifier = spyk(PresentationVerifier(), recordPrivateCalls = true)
+
+        every {
+            verifier["verifyPresentationProof"](any<JsonLDObject>())
+        } returns true
+
+        val result = verifier.verifyV2(vp)
+
+        assertFalse(result.proofVerificationResult.verificationStatus)
+
+        assertEquals(
+            HOLDER_VERIFICATION_FAIL_ERROR,
+            result.proofVerificationResult.verificationErrorCode
+        )
+    }
+
+   
 }

--- a/vc-verifier/kotlin/vcverifier/src/test/java/io/mosip/vercred/vcverifier/PresentationVerifierTest.kt
+++ b/vc-verifier/kotlin/vcverifier/src/test/java/io/mosip/vercred/vcverifier/PresentationVerifierTest.kt
@@ -881,7 +881,7 @@ class PresentationVerifierTest {
     }
 
     @Test
-    fun `validateHolderProofOfPossession should skip unsupported DID method`() {
+    fun `validateHolderProofOfPossession should fail for unsupported DID method`() {
 
         val verifier = PresentationVerifier()
 
@@ -912,9 +912,16 @@ class PresentationVerifierTest {
 
         method.isAccessible = true
 
-        assertDoesNotThrow {
+        val exception = assertThrows<java.lang.reflect.InvocationTargetException> {
             method.invoke(verifier, jsonLdObject, holderKey)
         }
+
+        val cause = exception.cause as HolderBindingException
+
+        assertEquals(
+            HOLDER_VERIFICATION_FAIL_ERROR,
+            cause.errorCode
+        )
     }
 
     @Test

--- a/vc-verifier/kotlin/vcverifier/src/test/resources/vp/EmptyVerifiableCredentialVP.json
+++ b/vc-verifier/kotlin/vcverifier/src/test/resources/vp/EmptyVerifiableCredentialVP.json
@@ -1,0 +1,17 @@
+{
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1"
+  ],
+  "type": [
+    "VerifiablePresentation"
+  ],
+  "holder": "did:key:z6MkktrAxN4k3x1Yqk6bM8z7G7nF4jM8o6x3V9dP2nQx8YwR",
+  "verifiableCredential": [],
+  "proof": {
+    "type": "Ed25519Signature2018",
+    "created": "2024-01-01T00:00:00Z",
+    "proofPurpose": "authentication",
+    "verificationMethod": "did:key:z6MkktrAxN4k3x1Yqk6bM8z7G7nF4jM8o6x3V9dP2nQx8YwR#z6MkktrAxN4k3x1Yqk6bM8z7G7nF4jM8o6x3V9dP2nQx8YwR",
+    "jws": "dummy-signature"
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Replace legacy publicKey/resolver imports with the new keyResolver-based API from release-1.5.x onward.

* **New Features**
  * Added ECC R1 and K1 key support.
  * Added verification support for did:jwk and did:key (Ed25519, P-256).
  * Presentation holder-binding now performs explicit proof-of-possession checks.

* **Bug Fixes**
  * Missing verifiableCredential treated as empty during verification.
  * Holder-binding failures returned as structured verification results (no uncaught exceptions).

* **Documentation**
  * README expanded with migration notes and detailed holder-binding verification behavior.

* **Tests**
  * Expanded test coverage and added an empty-presentation test resource.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/inji/vc-verifier/pull/253?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->