### PR TITLE
refactor: udpate license to Apache 2.0

### DIFF
--- a/.github/workflows/kotlin-artifacts-build.yml
+++ b/.github/workflows/kotlin-artifacts-build.yml
@@ -42,7 +42,7 @@ jobs:
       ANDROID_SERVICE_LOCATION: 'vcverifier'
       GROUP_PATH: ${{ inputs.group_path }}   #dynamic
       JAVA_VERSION: 21
-      LICENSE_NAME: 'MPL-2.0'
+      LICENSE_NAME: 'Apache 2.0'
       RELEASE_TYPE: ${{ inputs.release_type }}
     secrets:
       OSSRH_USER: ${{ secrets.OSSRH_USER }}
@@ -60,7 +60,7 @@ jobs:
       ANDROID_SERVICE_LOCATION: 'vcverifier'
       GROUP_PATH: ${{ inputs.group_path }}   #dynamic
       JAVA_VERSION: 21
-      LICENSE_NAME: 'MPL-2.0'
+      LICENSE_NAME: 'Apache 2.0'
       RELEASE_TYPE: ${{ inputs.release_type }}
       PUBLICATION_TYPE: ${{ inputs.publication_type }}
     secrets:

--- a/vc-verifier/kotlin/vcverifier/publish-artifact.gradle
+++ b/vc-verifier/kotlin/vcverifier/publish-artifact.gradle
@@ -32,8 +32,8 @@ publishing {
                     asNode().appendNode('description', "Kotlin library to generate QR code from VC and decode the data")
 
                     asNode().appendNode('licenses').appendNode('license').with {
-                        appendNode('name', 'MPL-2.0')
-                        appendNode('url', 'https://www.mozilla.org/en-US/MPL/2.0/')
+                        appendNode('name', 'Apache 2.0')
+                        appendNode('url', 'https://www.apache.org/licenses/LICENSE-2.0')
                     }
 
                     asNode().appendNode('scm').with {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated published package metadata to identify the software license as Apache 2.0.
  * Applied the license information consistently across snapshot and release publications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->