### PR TITLE
fix: change validateKeyBindingJwt default from true to false

### DIFF
--- a/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/CredentialsVerifier.kt
+++ b/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/CredentialsVerifier.kt
@@ -39,7 +39,7 @@ class CredentialsVerifier {
     }
 
     @JvmOverloads
-    fun verify(credential: String, credentialFormat: CredentialFormat, validateKeyBindingJwt: Boolean = true): VerificationResult {
+    fun verify(credential: String, credentialFormat: CredentialFormat, validateKeyBindingJwt: Boolean = false): VerificationResult {
         val credentialVerifier = credentialVerifierFactory.get(credentialFormat)
         val validationStatus = credentialVerifier.validate(credential, validateKeyBindingJwt)
         if (validationStatus.validationMessage.isNotEmpty() && !validationStatus.validationErrorCode.contentEquals(
@@ -96,7 +96,7 @@ class CredentialsVerifier {
         credential: String,
         credentialFormat: CredentialFormat,
         statusPurposeList: List<String> = emptyList(),
-        validateKeyBindingJwt: Boolean = true
+        validateKeyBindingJwt: Boolean = false
     ): CredentialVerificationSummary {
         val verificationResult = verify(credential, credentialFormat, validateKeyBindingJwt)
         if (verificationResult.verificationStatus) {

--- a/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/credentialverifier/VerifiableCredential.kt
+++ b/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/credentialverifier/VerifiableCredential.kt
@@ -5,7 +5,7 @@ import io.mosip.vercred.vcverifier.data.ValidationStatus
 
 interface VerifiableCredential {
     fun validate(credential: String): ValidationStatus
-    fun validate(credential: String, validateKeyBindingJwt: Boolean = true): ValidationStatus =
+    fun validate(credential: String, validateKeyBindingJwt: Boolean = false): ValidationStatus =
         validate(credential)
     fun verify(credential: String): Boolean
     fun checkStatus(credential: String, statusPurposes: List<String>?): Map<String, CredentialStatusResult> {

--- a/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/credentialverifier/types/SdJwtVerifiableCredential.kt
+++ b/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/credentialverifier/types/SdJwtVerifiableCredential.kt
@@ -7,7 +7,7 @@ import io.mosip.vercred.vcverifier.data.ValidationStatus
 
 class SdJwtVerifiableCredential: VerifiableCredential {
     override fun validate(credential: String): ValidationStatus {
-        return validate(credential, validateKeyBindingJwt = true)
+        return validate(credential, validateKeyBindingJwt = false)
     }
 
     override fun validate(credential: String, validateKeyBindingJwt: Boolean): ValidationStatus {

--- a/vc-verifier/kotlin/vcverifier/src/test/java/io/mosip/vercred/vcverifier/CredentialsVerifierTest.kt
+++ b/vc-verifier/kotlin/vcverifier/src/test/java/io/mosip/vercred/vcverifier/CredentialsVerifierTest.kt
@@ -305,4 +305,28 @@ class CredentialsVerifierTest {
         assertTrue(verificationResult.verificationStatus)
         assertEquals("", verificationResult.verificationErrorCode)
     }
+
+    @Test
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    fun `verify SD-JWT without flag defaults to false and succeeds without KB-JWT`() {
+        val vc = readClasspathFile("sd-jwt_vc/sdJwtWithRootLevelSdNestedPayload.txt")
+
+        val verificationResult = CredentialsVerifier().verify(vc, VC_SD_JWT)
+
+        assertTrue(verificationResult.verificationStatus)
+        assertEquals("", verificationResult.verificationMessage)
+        assertEquals("", verificationResult.verificationErrorCode)
+    }
+
+    @Test
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    fun `verifyAndGetCredentialStatus SD-JWT without flag defaults to false and succeeds without KB-JWT`() {
+        val vc = readClasspathFile("sd-jwt_vc/sdJwtWithRootLevelSdNestedPayload.txt")
+
+        val result = CredentialsVerifier().verifyAndGetCredentialStatus(vc, VC_SD_JWT)
+
+        assertTrue(result.verificationResult.verificationStatus)
+        assertEquals("", result.verificationResult.verificationMessage)
+        assertEquals("", result.verificationResult.verificationErrorCode)
+    }
 }


### PR DESCRIPTION
KB-JWT is only present during SD-JWT presentation, not issuance.                                                                                 Hardcoded default of true was causing SD-JWT download to fail during OpenID4VCI credential issuance.  