### PR TITLE
fix: handle EC curve name resolution across JCA providers

### DIFF
--- a/vc-verifier/kotlin/vcverifier/publish-artifact.gradle
+++ b/vc-verifier/kotlin/vcverifier/publish-artifact.gradle
@@ -96,7 +96,7 @@ publishing {
             }
             groupId = "io.inji"
             artifactId = "vcverifier-aar"
-            version = "2.0.0-SNAPSHOT"
+            version = "1.10.0-SNAPSHOT"
             if (project.gradle.startParameter.taskNames.any { it.contains('assembleRelease') }) {
                 artifacts {
                     aar {
@@ -110,7 +110,7 @@ publishing {
             artifact(tasks.named("jarRelease").get())
             groupId = "io.inji"
             artifactId = "vcverifier-jar"
-            version = "2.0.0-SNAPSHOT"
+            version = "1.10.0-SNAPSHOT"
             artifact(tasks.named("javadocJar").get())
             artifact(tasks.named("sourcesJar").get())
             pom {

--- a/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/credentialverifier/verifier/SdJwtVerifier.kt
+++ b/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/credentialverifier/verifier/SdJwtVerifier.kt
@@ -19,7 +19,7 @@ class SdJwtVerifier {
         require(parts.size == 3) { "Invalid JWT format" }
 
         val jwsObject = JWSObject.parse(jwt)
-        val certBase64 = jwsObject.header.x509CertChain.firstOrNull()?.toString()
+        val certBase64 = jwsObject.header.x509CertChain?.firstOrNull()?.toString()
             ?: throw IllegalArgumentException("No X.509 certificate found in JWT header")
 
         val publicKey = getPublicKeyFromCertificate(certBase64)

--- a/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/signature/impl/ECDSASignatureVerifier.kt
+++ b/vc-verifier/kotlin/vcverifier/src/main/java/io/mosip/vercred/vcverifier/signature/impl/ECDSASignatureVerifier.kt
@@ -4,6 +4,7 @@ import io.mosip.vercred.vcverifier.constants.CredentialVerifierConstants
 import io.mosip.vercred.vcverifier.exception.SignatureVerificationException
 import io.mosip.vercred.vcverifier.signature.SignatureVerifier
 import io.mosip.vercred.vcverifier.signature.bouncyCastleProvider
+import org.bouncycastle.jce.ECNamedCurveTable
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.bouncycastle.jce.spec.ECNamedCurveSpec
 import java.io.ByteArrayOutputStream
@@ -11,6 +12,7 @@ import java.math.BigInteger
 import java.security.PublicKey
 import java.security.Signature
 import java.security.interfaces.ECPublicKey
+import java.security.spec.ECParameterSpec
 
 private const val ECDSA_SIGNATURE_LENGTH = 64
 
@@ -27,7 +29,7 @@ abstract class ECDSASignatureVerifier : SignatureVerifier {
     ): Boolean {
         val ecKey = publicKey as? ECPublicKey ?: throw SignatureVerificationException("Provided key is not an Elliptic Curve key")
         val params = ecKey.params
-        val curveName = (params as? ECNamedCurveSpec)?.name ?: params?.toString()
+        val curveName = resolveCurveName(params)
         if (curveName == null) {
             throw SignatureVerificationException("Unable to determine curve name for $algorithmName validation")
         }
@@ -54,6 +56,27 @@ abstract class ECDSASignatureVerifier : SignatureVerifier {
         } catch (e: Exception) {
             throw SignatureVerificationException("Error while doing signature verification using $algorithmName algorithm: $e")
         }
+    }
+
+    /**
+     * Resolves the standard name of the curve a key was generated on.
+     *
+     * Key parameters by provider:
+     *  - ECNamedCurveSpec (BouncyCastle) - carries the curve name, read directly
+     *  - ECParameterSpec (Conscrypt, the default provider on Android) - carries no name,
+     *    so the curve order is matched against ECNamedCurveTable
+     *
+     * The order is a property of the curve rather than of the provider that parsed the key.
+     * Returns null when no named curve matches the given parameters.
+     *
+     */
+    private fun resolveCurveName(params: ECParameterSpec?): String? {
+        if (params == null) return null
+        (params as? ECNamedCurveSpec)?.name?.let { return it }
+        return ECNamedCurveTable.getNames().toList().filterIsInstance<String>()
+            .firstOrNull { name ->
+                ECNamedCurveTable.getParameterSpec(name)?.n == params.order
+            }
     }
 
     /**

--- a/vc-verifier/kotlin/vcverifier/src/test/java/io/mosip/vercred/vcverifier/credentialverifier/verifier/SdJwtVerifierTest.kt
+++ b/vc-verifier/kotlin/vcverifier/src/test/java/io/mosip/vercred/vcverifier/credentialverifier/verifier/SdJwtVerifierTest.kt
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.springframework.util.ResourceUtils
 import java.nio.file.Files
+import java.util.Base64
 
 class SdJwtVerifierTest{
 
@@ -38,5 +39,31 @@ class SdJwtVerifierTest{
         }
 
         assertEquals("Credential status checking not supported for this credential format",unsupportedStatusCheckException.message)
+    }
+
+    @Test
+    fun `should throw exception for sd-jwt whose header carries no x5c`() {
+        val missingCertificateException = assertThrows(IllegalArgumentException::class.java) {
+            SdJwtVerifier().verify(sdJwtWithHeader("""{"alg":"ES256","typ":"vc+sd-jwt"}"""))
+        }
+
+        assertEquals("No X.509 certificate found in JWT header", missingCertificateException.message)
+    }
+
+    @Test
+    fun `should throw exception for sd-jwt whose x5c is an empty chain`() {
+        val emptyCertificateChainException = assertThrows(IllegalArgumentException::class.java) {
+            SdJwtVerifier().verify(sdJwtWithHeader("""{"alg":"ES256","typ":"vc+sd-jwt","x5c":[]}"""))
+        }
+
+        assertEquals("No X.509 certificate found in JWT header", emptyCertificateChainException.message)
+    }
+
+    private fun sdJwtWithHeader(header: String): String {
+        val encoder = Base64.getUrlEncoder().withoutPadding()
+        val payload = encoder.encodeToString("""{"iss":"https://issuer.example"}""".toByteArray())
+        val signature = encoder.encodeToString(ByteArray(64))
+
+        return "${encoder.encodeToString(header.toByteArray())}.$payload.$signature~"
     }
 }

--- a/vc-verifier/kotlin/vcverifier/src/test/java/io/mosip/vercred/vcverifier/signature/impl/ECDSASignatureVerifierTest.kt
+++ b/vc-verifier/kotlin/vcverifier/src/test/java/io/mosip/vercred/vcverifier/signature/impl/ECDSASignatureVerifierTest.kt
@@ -1,0 +1,138 @@
+package io.mosip.vercred.vcverifier.signature.impl
+
+import io.mosip.vercred.vcverifier.exception.SignatureVerificationException
+import org.bouncycastle.jce.ECNamedCurveTable
+import org.bouncycastle.jce.provider.BouncyCastleProvider
+import org.bouncycastle.jce.spec.ECNamedCurveSpec
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.math.BigInteger
+import java.security.KeyPair
+import java.security.KeyPairGenerator
+import java.security.Signature
+import java.security.interfaces.ECPublicKey
+import java.security.spec.ECFieldFp
+import java.security.spec.ECGenParameterSpec
+import java.security.spec.ECParameterSpec
+import java.security.spec.ECPoint
+import java.security.spec.EllipticCurve
+
+private const val CURVE = "secp256r1"
+private const val SIGNED_DATA = "verifiable credential payload"
+
+/**
+ * Guards the curve check against provider differences.
+ *
+ * BouncyCastle reports key parameters as an ECNamedCurveSpec, but Conscrypt - the default
+ * X.509 provider on Android - reports a plain ECParameterSpec that carries no curve name.
+ * These tests cover both shapes so the Android path is exercised on the JVM.
+ */
+class ECDSASignatureVerifierTest {
+
+    private val provider = BouncyCastleProvider()
+
+    /** Reports a plain [ECParameterSpec] for an otherwise valid key, as Conscrypt does. */
+    private class UnnamedCurveEcPublicKey(
+        private val delegate: ECPublicKey,
+        private val unnamedParams: ECParameterSpec,
+    ) : ECPublicKey by delegate {
+        override fun getParams(): ECParameterSpec = unnamedParams
+    }
+
+    @Test
+    fun `should verify a key whose parameters carry the curve name`() {
+        val keyPair = generateKeyPair()
+        val signature = sign(keyPair, SIGNED_DATA)
+
+        assertTrue(
+            ES256SignatureVerifierImpl()
+                .verify(keyPair.public, SIGNED_DATA.toByteArray(), signature, provider)
+        )
+    }
+
+    @Test
+    fun `should verify a key whose parameters carry no curve name`() {
+        val keyPair = generateKeyPair()
+        val signature = sign(keyPair, SIGNED_DATA)
+        val publicKey = withoutCurveName(keyPair.public as ECPublicKey)
+
+        assertFalse(publicKey.params is ECNamedCurveSpec)
+        assertTrue(
+            ES256SignatureVerifierImpl()
+                .verify(publicKey, SIGNED_DATA.toByteArray(), signature, provider)
+        )
+    }
+
+    @Test
+    fun `should reject a key whose parameters carry no curve name and a mismatched curve`() {
+        val keyPair = generateKeyPair()
+        val signature = sign(keyPair, SIGNED_DATA)
+        val publicKey = withoutCurveName(keyPair.public as ECPublicKey)
+
+        val exception = assertThrows<SignatureVerificationException> {
+            ES256KSignatureVerifierImpl()
+                .verify(publicKey, SIGNED_DATA.toByteArray(), signature, provider)
+        }
+
+        assertTrue(exception.message!!.contains("does not match proof type"))
+    }
+
+    private fun generateKeyPair(): KeyPair =
+        KeyPairGenerator.getInstance("EC", provider)
+            .apply { initialize(ECGenParameterSpec(CURVE)) }
+            .generateKeyPair()
+
+    /** Rebuilds the key parameters as a plain [ECParameterSpec], dropping the curve name. */
+    private fun withoutCurveName(publicKey: ECPublicKey): ECPublicKey {
+        val curve = ECNamedCurveTable.getParameterSpec(CURVE)
+        val field = curve.curve.field.characteristic
+        val unnamedParams = ECParameterSpec(
+            EllipticCurve(
+                ECFieldFp(field),
+                curve.curve.a.toBigInteger(),
+                curve.curve.b.toBigInteger(),
+            ),
+            ECPoint(
+                curve.g.normalize().affineXCoord.toBigInteger(),
+                curve.g.normalize().affineYCoord.toBigInteger(),
+            ),
+            curve.n,
+            curve.h.toInt(),
+        )
+        return UnnamedCurveEcPublicKey(publicKey, unnamedParams)
+    }
+
+    /** Signs [data] and returns the signature in the raw R || S form the verifier expects. */
+    private fun sign(keyPair: KeyPair, data: String): ByteArray {
+        val derSignature = Signature.getInstance("SHA256withECDSA", provider)
+            .apply {
+                initSign(keyPair.private)
+                update(data.toByteArray())
+            }
+            .sign()
+        return derToRaw(derSignature)
+    }
+
+    private fun derToRaw(derSignature: ByteArray): ByteArray {
+        var offset = 3
+        val rLength = derSignature[offset].toInt()
+        offset++
+        val r = BigInteger(1, derSignature.copyOfRange(offset, offset + rLength))
+        offset += rLength + 1
+        val sLength = derSignature[offset].toInt()
+        offset++
+        val s = BigInteger(1, derSignature.copyOfRange(offset, offset + sLength))
+
+        return toFixedWidth(r) + toFixedWidth(s)
+    }
+
+    private fun toFixedWidth(value: BigInteger): ByteArray {
+        val bytes = value.toByteArray()
+        val fixed = ByteArray(32)
+        val source = if (bytes.size > 32) bytes.copyOfRange(bytes.size - 32, bytes.size) else bytes
+        source.copyInto(fixed, 32 - source.size)
+        return fixed
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Improved verification reliability when JWTs omit certificate information, with clear handling for unavailable or empty certificate chains.
* Enhanced ECDSA signature verification for keys whose elliptic-curve name is not explicitly provided.
* Added support for identifying supported curves through their parameters, improving compatibility across credential formats.
* Added validation to reject signatures using mismatched elliptic curves.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->